### PR TITLE
fix: refine permissions in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Lexin dictionary",
-  "version": "2.0.0.66",
+  "version": "2.0.0.68",
   "description": "Swedish to other languages dictionary. Powered by Lexin and Folkets Lexikon",
   "icons": {
     "16": "icons/icon16.png",
@@ -23,20 +23,7 @@
     "http://folkets-lexikon.csc.kth.se/*"
   ],
   "permissions": [
-    "storage",
-    "tabs"
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": [
-        "scripts/*.js",
-        "scripts/dictionary/*.js",
-        "scripts/messaging/*.js"
-      ],
-      "matches": [
-        "<all_urls>"
-      ]
-    }
+    "storage"
   ],
   "content_scripts": [
     {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Lexin dictionary",
-  "version": "2.0.0.68",
+  "version": "2.0.0.70",
   "description": "Swedish to other languages dictionary. Powered by Lexin and Folkets Lexikon",
   "icons": {
     "16": "icons/icon16.png",

--- a/src/scripts/messaging/ChromeMessageBus.ts
+++ b/src/scripts/messaging/ChromeMessageBus.ts
@@ -30,10 +30,23 @@ class ChromeMessageBus implements IMessageBus {
     sendMessageToActiveTab(method: MessageType, args: any): Promise<any> {
         return new Promise((resolve) => {
             chrome.tabs.query({active: true, currentWindow: true}, function (tabs) {
-                chrome.tabs.sendMessage(tabs[0].id, {method: method, args: args}, function (response: any) {
-                    if (response) {
-                        resolve(response);
-                    }
+                // No addressable tab, e.g. devtools or another extension window
+                // is focused. tabs[0] is undefined here, so guard before reading id.
+                const activeTabId = tabs[0]?.id;
+                if (activeTabId === undefined) {
+                    resolve(undefined);
+                    return;
+                }
+                chrome.tabs.sendMessage(activeTabId, {method: method, args: args}, function (response: any) {
+                    // lastError is set whenever no frame answered: a page with
+                    // nothing selected, where every frame stays silent by design
+                    // (see MessageHandlers.registerGetSelectionHandler), or a page
+                    // the content script cannot run on such as chrome:// or the
+                    // Web Store. Both are ordinary outcomes, so resolve instead of
+                    // leaving the promise pending. Reading lastError also marks it
+                    // handled and keeps the console clean.
+                    const unanswered = chrome.runtime.lastError !== undefined;
+                    resolve(unanswered ? undefined : response);
                 });
             });
         });

--- a/src/scripts/messaging/MessageService.ts
+++ b/src/scripts/messaging/MessageService.ts
@@ -19,7 +19,10 @@ class MessageService implements IMessageService{
     }
 
     getSelectedText(): Promise<string> {
-        return MessageBus.Instance.sendMessageToActiveTab(MessageType.getSelection);
+        // The bus resolves undefined when no frame answered; "no selection" is
+        // the string form of that, and keeps this method true to Promise<string>.
+        return MessageBus.Instance.sendMessageToActiveTab(MessageType.getSelection)
+            .then((selection) => selection ?? "");
     }
 
     createNewTab(url: string): void {

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -148,7 +148,9 @@ export class ExtensionHelpers {
   }
 
   /**
-   * Wait for translation to appear (not empty and not "Searching...")
+   * Wait for a real translation to appear - not empty, and not one of the
+   * placeholders the popup shows first: "Searching..." while a lookup is in
+   * flight, or "No word selected" when the popup opened with no page selection.
    */
   static async waitForTranslation(page: Page, timeout = 10000): Promise<void> {
     await page.waitForFunction(
@@ -156,7 +158,9 @@ export class ExtensionHelpers {
         const el = document.querySelector('#translation');
         if (!el) return false;
         const text = el.textContent || '';
-        return text.length > 0 && !text.includes('Searching');
+        return text.length > 0
+          && !text.includes('Searching')
+          && !text.includes('No word selected');
       },
       { timeout }
     );

--- a/tests/e2e/permissions.spec.ts
+++ b/tests/e2e/permissions.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from './fixtures';
+import MessageType from '../../src/scripts/messaging/MessageType';
+
+/**
+ * Verifies that the tab-dependent code paths still work under the permission
+ * set the extension actually ships (storage only, no "tabs").
+ *
+ * These paths are otherwise uncovered: the smoke tests open popup.html as a
+ * regular tab, so `tabs.query({active: true, currentWindow: true})` inside the
+ * popup resolves to the popup's own tab rather than a web page. Combined with
+ * ChromeMessageBus.sendMessageToActiveTab only resolving its promise when a
+ * response arrives - it neither rejects nor times out - a break in this path
+ * is silent and leaves the rest of the suite green.
+ */
+
+declare const chrome: any;
+
+const TEST_PAGE = 'http://localhost:3456/swedish-text.html';
+
+/** Text of #test-word on the test page, which each test selects. */
+const SELECTED_WORD = 'bil';
+
+test.describe('Shipped permission surface', () => {
+
+  test('loaded extension requests only the storage permission', async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/html/popup.html`);
+
+    // Asserts against the built dist/ manifest as Chrome parsed it, so a
+    // stale or hand-edited build is caught too - ManifestTests covers source.
+    const manifest = await page.evaluate(() => chrome.runtime.getManifest());
+
+    expect(manifest.permissions).toEqual(['storage']);
+    expect(manifest.web_accessible_resources).toBeUndefined();
+
+    await page.close();
+  });
+
+  test('active tab lookup yields an id but no url without the "tabs" permission', async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/html/popup.html`);
+
+    const tab = await page.evaluate(() => new Promise<{ id: unknown, url: unknown, error: string | null }>((resolve) => {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs: any[]) => resolve({
+        id: tabs[0]?.id ?? null,
+        url: tabs[0]?.url ?? null,
+        error: chrome.runtime.lastError?.message ?? null
+      }));
+    }));
+
+    expect(tab.error).toBeNull();
+    expect(typeof tab.id).toBe('number');
+
+    // Chrome strips url/title/favIconUrl without "tabs". sendMessageToActiveTab
+    // must therefore route on the id alone; a non-null url here means someone
+    // re-added the permission, and any code that starts reading tab.url would
+    // silently receive undefined once it is removed again.
+    expect(tab.url).toBeNull();
+
+    await page.close();
+  });
+
+  test('content script answers getSelection over tabs.sendMessage', async ({ context, extensionId }) => {
+    const web = await context.newPage();
+    await web.goto(TEST_PAGE);
+    await web.waitForLoadState('domcontentloaded');
+    await web.evaluate(() => {
+      const range = document.createRange();
+      range.selectNodeContents(document.querySelector('#test-word')!);
+      const selection = window.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+    });
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/html/popup.html`);
+
+    // tab.url is stripped, so the web tab cannot be picked out by URL - probe
+    // every tab and keep whatever answers. Tabs without a content script (the
+    // extension page, about:blank) report a lastError and resolve to null.
+    const responses = await page.evaluate((method) => new Promise<unknown[]>((resolve) => {
+      chrome.tabs.query({}, (tabs: any[]) => {
+        Promise.all(tabs.map((tab) => new Promise((done) => {
+          chrome.tabs.sendMessage(tab.id, { method, args: undefined }, (response: unknown) => {
+            void chrome.runtime.lastError;
+            done(response ?? null);
+          });
+        }))).then(resolve);
+      });
+    }), MessageType.getSelection);
+
+    expect(responses).toContain(SELECTED_WORD);
+
+    await page.close();
+    await web.close();
+  });
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -128,6 +128,19 @@ test.describe('Extension Smoke Tests', () => {
     await page.close();
   });
 
+  test('popup should report when no word is selected', async ({ popupPage }) => {
+    const page = await popupPage();
+
+    // The popup asks the active tab for its selection on open. Nothing answers
+    // here - the popup is itself the active tab and runs no content script -
+    // which is the same shape as opening the popup on a page with nothing
+    // selected. sendMessageToActiveTab must settle so this branch can render;
+    // it used to leave the promise pending and #translation stayed blank.
+    await expect(page.locator('#translation')).toHaveText('No word selected');
+
+    await page.close();
+  });
+
   test('navigation between extension pages should work', async ({ optionsPage }) => {
     const page = await optionsPage();
     

--- a/tests/unit/ChromeMessageBusTests.ts
+++ b/tests/unit/ChromeMessageBusTests.ts
@@ -1,0 +1,86 @@
+import ChromeMessageBus from "../../src/scripts/messaging/ChromeMessageBus.js";
+import MessageType from "../../src/scripts/messaging/MessageType.js";
+
+/**
+ * sendMessageToActiveTab used to resolve only when a response arrived, so every
+ * "nobody answered" path left the promise pending forever - PopupPage's
+ * "No word selected" branch could never run. These tests pin that the promise
+ * settles on all of them.
+ */
+describe("ChromeMessageBus.sendMessageToActiveTab", () => {
+
+    let messageBus: ChromeMessageBus;
+    let lastErrorReads: number;
+
+    /**
+     * Installs a chrome double whose tabs.sendMessage invokes its callback the
+     * way Chrome does: with a response, or with no response and lastError set.
+     * lastError reads are counted so we can assert Chrome will not log an
+     * "Unchecked runtime.lastError" warning.
+     */
+    function fakeChrome(options: { tabs: any[], response?: any, lastError?: string }) {
+        lastErrorReads = 0;
+        const runtime = {
+            get lastError() {
+                lastErrorReads++;
+                return options.lastError ? { message: options.lastError } : undefined;
+            }
+        };
+        (global as any).chrome = {
+            runtime,
+            tabs: {
+                query: (_query: any, callback: (tabs: any[]) => void) => callback(options.tabs),
+                sendMessage: (_id: number, _message: any, callback: (response: any) => void) =>
+                    callback(options.lastError ? undefined : options.response)
+            }
+        };
+    }
+
+    beforeEach(() => {
+        messageBus = new ChromeMessageBus();
+    });
+
+    afterEach(() => {
+        delete (global as any).chrome;
+    });
+
+    it("should resolve with the response when a frame answers", async () => {
+        fakeChrome({ tabs: [{ id: 7 }], response: "bil" });
+
+        await expect(messageBus.sendMessageToActiveTab(MessageType.getSelection, undefined))
+            .resolves.toBe("bil");
+    });
+
+    it("should resolve when no frame answers", async () => {
+        // Every frame stays silent when nothing is selected on the page.
+        fakeChrome({ tabs: [{ id: 7 }], lastError: "The message port closed before a response was received." });
+
+        await expect(messageBus.sendMessageToActiveTab(MessageType.getSelection, undefined))
+            .resolves.toBeUndefined();
+    });
+
+    it("should resolve when the tab has no content script", async () => {
+        // chrome:// pages and the Web Store, where the content script cannot run.
+        fakeChrome({ tabs: [{ id: 7 }], lastError: "Could not establish connection. Receiving end does not exist." });
+
+        await expect(messageBus.sendMessageToActiveTab(MessageType.getSelection, undefined))
+            .resolves.toBeUndefined();
+    });
+
+    it("should resolve when there is no active tab", async () => {
+        // tabs[0] is undefined when devtools or another extension window is focused;
+        // reading .id off it used to throw inside the callback and strand the promise.
+        fakeChrome({ tabs: [] });
+
+        await expect(messageBus.sendMessageToActiveTab(MessageType.getSelection, undefined))
+            .resolves.toBeUndefined();
+    });
+
+    it("should read lastError so Chrome does not log an unchecked error", async () => {
+        fakeChrome({ tabs: [{ id: 7 }], response: "bil" });
+
+        await messageBus.sendMessageToActiveTab(MessageType.getSelection, undefined);
+
+        expect(lastErrorReads).toBeGreaterThan(0);
+    });
+});

--- a/tests/unit/ManifestTests.ts
+++ b/tests/unit/ManifestTests.ts
@@ -1,0 +1,38 @@
+import manifest from "../../src/manifest.json";
+
+/**
+ * Guards the permission surface the extension ships to the Chrome Web Store.
+ *
+ * A submission was rejected for requesting "tabs", which none of the
+ * chrome.tabs calls in ChromeMessageBus need: tabs.create never required it,
+ * and tabs.query/tabs.sendMessage only lose the url/title/favIconUrl fields
+ * without it - fields this extension does not read.
+ *
+ * A failure here means the permission surface grew. Fix it by removing the
+ * permission, not by widening the expectation - unless the code genuinely
+ * cannot work without it, in which case the store will want a justification.
+ */
+describe("manifest permissions", () => {
+
+    it("should request only the storage permission", () => {
+        expect(manifest.permissions).toEqual(["storage"]);
+    });
+
+    it("should not request the tabs permission", () => {
+        expect(manifest.permissions).not.toContain("tabs");
+    });
+
+    it("should limit host permissions to the two dictionary services", () => {
+        expect(manifest.host_permissions).toEqual([
+            "http://lexin.nada.kth.se/*",
+            "http://folkets-lexikon.csc.kth.se/*"
+        ]);
+    });
+
+    it("should not expose any resource to web pages", () => {
+        // Every entry point is bundled into a self-contained IIFE and loaded
+        // either as a content script or from an extension page, so no script
+        // needs to be fetchable by a web page.
+        expect(manifest).not.toHaveProperty("web_accessible_resources");
+    });
+});


### PR DESCRIPTION
## Narrow the manifest permission surface

A Chrome Web Store submission was rejected for requesting `tabs`. This removes it, along with the unused `web_accessible_resources` block, and fixes the message-bus bug that removal exposed.

### Manifest — [src/manifest.json](https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/blob/8ebb71cbcf0346693a4ddb6dfad39eddf1dfc684/src/manifest.json)
- `permissions` reduced to `["storage"]`. `tabs.create` never needed `tabs`; `tabs.query`/`tabs.sendMessage` only lose `url`/`title`/`favIconUrl` without it, and none of those are read.
- Dropped `web_accessible_resources` — every entry point is a self-contained IIFE loaded as a content script or from an extension page, so nothing needs to be fetchable by a web page.


### Message bus — [ChromeMessageBus.ts:30-52](https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/blob/8ebb71cbcf0346693a4ddb6dfad39eddf1dfc684/src/scripts/messaging/ChromeMessageBus.ts#L30-L52)
`sendMessageToActiveTab` only resolved when a response arrived, so any "nobody answered" path left the promise pending forever and the popup rendered a blank `#translation`. Now it:
- Guards `tabs[0]?.id` — undefined when devtools or another extension window is focused; reading `.id` used to throw inside the callback and strand the promise.
- Reads `chrome.runtime.lastError` and resolves `undefined` when no frame answered (nothing selected on the page, or a page like `chrome://` where the content script can't run). Reading `lastError` also keeps the console free of "Unchecked runtime.lastError".

[MessageService.getSelectedText](https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/blob/8ebb71cbcf0346693a4ddb6dfad39eddf1dfc684/src/scripts/messaging/MessageService.ts#L21-L26) maps that `undefined` to `""`, staying true to its `Promise<string>` signature.

### Tests
- [tests/unit/ManifestTests.ts](https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/blob/8ebb71cbcf0346693a4ddb6dfad39eddf1dfc684/tests/unit/ManifestTests.ts) — pins permissions, host permissions, and the absence of `web_accessible_resources` against the source manifest.
- [tests/unit/ChromeMessageBusTests.ts](https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/blob/8ebb71cbcf0346693a4ddb6dfad39eddf1dfc684/tests/unit/ChromeMessageBusTests.ts) — a chrome double covering all four settle paths plus the `lastError` read.
- [tests/e2e/permissions.spec.ts](https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/blob/8ebb71cbcf0346693a4ddb6dfad39eddf1dfc684/tests/e2e/permissions.spec.ts) — checks the built `dist/` manifest as Chrome parsed it, asserts `tab.url` is stripped (so nothing starts depending on it), and confirms the content script still answers `getSelection` over `tabs.sendMessage`.
- [tests/e2e/smoke.spec.ts:131-142](https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/blob/8ebb71cbcf0346693a4ddb6dfad39eddf1dfc684/tests/e2e/smoke.spec.ts#L131-L142) — regression test that the popup renders "No word selected" instead of staying blank.
- [tests/e2e/fixtures.ts:155-167](https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/blob/8ebb71cbcf0346693a4ddb6dfad39eddf1dfc684/tests/e2e/fixtures.ts#L155-L167) — `waitForTranslation` now also skips the "No word selected" placeholder.
