### PR TITLE
feat: say when history recording is off, and turn it back on from the History page

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -382,6 +382,38 @@
     margin-top: var(--lx-space-2);
 }
 
+/* ── Notice ──────────────────────────────────────────────────────────────────── */
+
+/* A standing condition the reader should know about, with the control that ends it.
+   Unlike the toast, it reports something still true rather than something that just
+   happened, so it sits in the flow above the content it qualifies and stays put. */
+.lxNotice {
+    display: flex;
+    align-items: center;
+    gap: var(--lx-space-2);
+    margin-block: var(--lx-space-3);
+    padding: var(--lx-space-2) var(--lx-space-3);
+    border: 1px solid var(--lx-divider);
+    border-radius: var(--lx-radius);
+    background: var(--lx-accent-tint);
+    font-size: 13px;
+    color: var(--lx-text);
+}
+
+.lxNoticeIcon {
+    flex: none;
+    color: var(--lx-accent-text);
+}
+
+/* The control last, and hard against the inline end - the sentence is what gets read
+   first, and the button is the answer to it. */
+.lxNotice .lxButton {
+    margin-inline-start: auto;
+    flex: none;
+    font-size: 13px;
+    background: var(--lx-surface);
+}
+
 /* ── Toast ───────────────────────────────────────────────────────────────────── */
 
 /* Confirms something that already happened. Fixed, so it never reflows the page it

--- a/src/scripts/history/HistoryModel.ts
+++ b/src/scripts/history/HistoryModel.ts
@@ -1,5 +1,6 @@
 import { IMessageService, IHistoryItem } from "../common/Interfaces.js";
 import LanguageManager from "../common/LanguageManager.js";
+import Settings from "../common/Settings.js";
 
 /** A history entry plus which Language Direction it came from. */
 export interface IHistoryRow extends IHistoryItem {
@@ -12,15 +13,33 @@ export const ALL_DIRECTIONS = "*";
 class HistoryModel {
     private messageService: IMessageService;
     private languageManager: LanguageManager;
+    private settings: Settings;
 
-    constructor(MessageService: IMessageService, languageManager: LanguageManager) {
+    constructor(MessageService: IMessageService, languageManager: LanguageManager,
+        settings: Settings) {
         this.messageService = MessageService;
         this.languageManager = languageManager;
+        this.settings = settings;
     }
 
     /** The reader's default Language Direction, used to pick the opening tab. */
     async getLanguage(): Promise<string> {
         return await this.languageManager.getCurrentLanguage();
+    }
+
+    /**
+     * Whether new lookups are still being added to the store.
+     *
+     * The History page is where a reader notices the setting - it is the list that
+     * stops growing - so it both reports it and can turn it back on, rather than
+     * sending them to Options for a single radio.
+     */
+    getRecordHistory(): Promise<boolean> {
+        return this.settings.getRecordHistory();
+    }
+
+    setRecordHistory(value: boolean): Promise<void> {
+        return this.settings.setRecordHistory(value);
     }
 
     /**

--- a/src/scripts/history/HistoryPage.ts
+++ b/src/scripts/history/HistoryPage.ts
@@ -40,6 +40,7 @@ class HistoryPage {
     private visible: IHistoryRow[] = [];
     private selected = new Set<string>();
     private query = "";
+    private recording = true;
 
     constructor(model: HistoryModel, languageLabel: LanguageLabel) {
         this.model = model;
@@ -51,6 +52,7 @@ class HistoryPage {
         DomUtils.append(DomUtils.$("#searchIcon"), Icons.search());
 
         this.readerLanguage = await this.model.getLanguage();
+        this.recording = await this.model.getRecordHistory();
         this.directions = this.sortDirections(await this.model.loadDirections());
 
         // Open on the reader's own language when it has history; otherwise All, which
@@ -182,13 +184,26 @@ class HistoryPage {
         DomUtils.empty(container);
 
         if (this.rows.length === 0) {
-            DomUtils.append(container, States.emptyState(
-                "No translations yet",
-                "Alt + double-click a word on any Swedish page to start building your list."));
+            // An empty list has two quite different causes, and only one of them is
+            // answered by "go and look a word up".
+            DomUtils.append(container, this.recording
+                ? States.emptyState(
+                    "No translations yet",
+                    "Alt + double-click a word on any Swedish page to start building your list.")
+                : States.emptyState(
+                    "Recording is off",
+                    "Lookups are not being saved, so this list stays empty.",
+                    this.recordingButton("Turn recording on", "lxButtonPrimary")));
             this.setToolbarEnabled(false);
             return;
         }
         this.setToolbarEnabled(true);
+
+        // The list is here but frozen. Said once, above it, rather than leaving a
+        // reader to work out for themselves why today's words never arrived.
+        if (!this.recording) {
+            DomUtils.append(container, this.recordingNotice());
+        }
 
         if (this.visible.length === 0) {
             DomUtils.append(container, States.emptyState(
@@ -322,6 +337,43 @@ class HistoryPage {
         tbody.appendChild(fragment);
         DomUtils.append(table, tbody);
         DomUtils.append(container, table);
+    }
+
+    /** A one-line reminder above a list that has stopped growing. */
+    private recordingNotice(): HTMLElement {
+        const notice = DomUtils.createElement("div", { role: "status" });
+        DomUtils.addClass(notice, "lxNotice");
+
+        const icon = Icons.info();
+        icon.setAttribute("class", "lxNoticeIcon");
+        DomUtils.append(notice, icon);
+
+        DomUtils.append(notice, DomUtils.createElement("span", undefined,
+            "Recording is off — new lookups are not being added to this list."));
+        DomUtils.append(notice, this.recordingButton("Turn on", "lxButtonSecondary"));
+        return notice;
+    }
+
+    private recordingButton(label: string, variant: string): HTMLElement {
+        const button = DomUtils.createElement("button", { type: "button" }, label);
+        DomUtils.addClass(button, "lxButton");
+        DomUtils.addClass(button, variant);
+        button.addEventListener("click", () => this.enableRecording());
+        return button;
+    }
+
+    /**
+     * Turned on from here rather than by sending the reader to Options.
+     *
+     * The service worker reads the setting per lookup out of the same chrome.storage,
+     * so the next word is recorded without either page reloading.
+     */
+    private async enableRecording(): Promise<void> {
+        await this.model.setRecordHistory(true);
+        this.recording = true;
+        Tracker.track("recordHistory", "changed", "true");
+        showToast("Recording is on");
+        this.renderTable();
     }
 
     private setToolbarEnabled(enabled: boolean): void {

--- a/src/scripts/history/history.ts
+++ b/src/scripts/history/history.ts
@@ -5,6 +5,7 @@ import LanguageLabel from "../common/LanguageLabel.js";
 import ThemeManager, { applyTheme } from "../common/ThemeManager.js";
 import HistoryModel from "./HistoryModel.js";
 import HistoryPage from "./HistoryPage.js";
+import Settings from "../common/Settings.js";
 import { createChromeStorage } from "../common/ChromeStorageAdapter.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -20,6 +21,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     const dictionaryFactory = new DictionaryFactory();
     const languageManager = new LanguageManager(settingsStorage, dictionaryFactory);
     const languageLabel = new LanguageLabel(settingsStorage, dictionaryFactory.getAllSupportedLanguages());
-    const historyModel = new HistoryModel(messageService, languageManager);
+    const historyModel = new HistoryModel(messageService, languageManager, new Settings(settingsStorage));
     new HistoryPage(historyModel, languageLabel);
 });

--- a/src/scripts/util/Icons.ts
+++ b/src/scripts/util/Icons.ts
@@ -68,6 +68,14 @@ export function alert(size: number = 22): SVGElement {
     return svg;
 }
 
+/** Lucide "info" - a standing condition the reader should know about, not an error. */
+export function info(size: number = 16): SVGElement {
+    const svg = withCircle(createSvg(size), 12, 12, 10);
+    withPath(svg, "M12 16v-4");
+    withPath(svg, "M12 8h.01");
+    return svg;
+}
+
 /**
  * Lucide "arrow-right-left" - flip the lookup direction.
  *

--- a/src/scripts/util/States.ts
+++ b/src/scripts/util/States.ts
@@ -56,11 +56,19 @@ export function errorState(detail: string): HTMLElement {
     return element;
 }
 
-/** Shown when there is nothing to look up yet. */
-export function emptyState(title: string, detail: string): HTMLElement {
+/**
+ * Shown when there is nothing to look up yet.
+ *
+ * `action` is for the empty that has a way out - a control that fills the list rather
+ * than a sentence telling the reader to go and find one elsewhere.
+ */
+export function emptyState(title: string, detail: string, action?: HTMLElement): HTMLElement {
     const element = state();
     DomUtils.append(element, line(title, "lxStateTitle"));
     DomUtils.append(element, line(detail));
+    if (action) {
+        DomUtils.append(element, action);
+    }
     return element;
 }
 

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -147,6 +147,23 @@ export class ExtensionHelpers {
     await page.close();
   }
 
+  /**
+   * Turn history recording off (or on) without walking the Options page.
+   *
+   * Stored as the string Settings writes: anything other than "false" means on.
+   */
+  static async setRecordHistory(
+    context: BrowserContext, extensionId: string, value: boolean
+  ): Promise<void> {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/html/help.html`);
+    await page.waitForLoadState("domcontentloaded");
+    await page.evaluate(async (recording) => {
+      await chrome.storage.local.set({ recordHistory: recording });
+    }, value ? "true" : "false");
+    await page.close();
+  }
+
   /** Reads one settings key back, for assertions about what a surface persisted. */
   static async getStoredValue(
     context: BrowserContext, extensionId: string, key: string

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -258,8 +258,45 @@ test.describe("Extension Smoke Tests", () => {
     await expect(history.locator("#historyCount")).toHaveText("1 word");
     await expect(history.locator("#history")).toContainText("gammal");
     await expect(history.locator("#history")).not.toContainText("bil");
+    // And the list says why it stopped growing, rather than leaving the reader to
+    // guess at it.
+    await expect(history.locator(".lxNotice")).toContainText("Recording is off");
 
     await history.close();
+  });
+
+  test("history page turns recording back on itself", async ({ context, extensionId, historyPage }) => {
+    await ExtensionHelpers.setRecordHistory(context, extensionId, false);
+    await ExtensionHelpers.seedHistory(context, extensionId, {
+      swe_eng: [{ word: "gammal", translation: "old", added: Date.parse("2026-07-01T10:00:00Z") }]
+    });
+
+    const page = await historyPage();
+    await page.locator(".lxNotice .lxButton").click();
+
+    await expect(page.locator(".lxToast")).toContainText("Recording is on");
+    await expect(page.locator(".lxNotice")).toHaveCount(0);
+    // What the service worker reads before it stores the next lookup.
+    expect(await ExtensionHelpers.getStoredValue(context, extensionId, "recordHistory")).toBe("true");
+
+    await page.close();
+  });
+
+  test("an empty history says which of the two empties it is", async ({ context, extensionId, historyPage }) => {
+    await ExtensionHelpers.setRecordHistory(context, extensionId, false);
+
+    const page = await historyPage();
+
+    // Not "Alt + double-click to start building your list" - that advice builds
+    // nothing while recording is off.
+    await expect(page.locator("#history")).toContainText("Recording is off");
+    await expect(page.locator("#history")).not.toContainText("Alt + double-click");
+    await page.locator("#history .lxButton").click();
+
+    await expect(page.locator("#history")).toContainText("No translations yet");
+    await expect(page.locator("#history")).toContainText("Alt + double-click");
+
+    await page.close();
   });
 
   test("history page should open and display UI elements", async ({ historyPage }) => {

--- a/tests/unit/HistoryModelTests.ts
+++ b/tests/unit/HistoryModelTests.ts
@@ -1,6 +1,7 @@
 import HistoryModel, { ALL_DIRECTIONS } from "../../src/scripts/history/HistoryModel.js";
 import DictionaryFactory from "../../src/scripts/dictionary/DictionaryFactory.js";
 import LanguageManager from "../../src/scripts/common/LanguageManager.js";
+import Settings from "../../src/scripts/common/Settings.js";
 import { TestMessageService, FakeAsyncSettingsStorage } from "./util/fakes.js";
 import { IAsyncSettingsStorage } from "../../src/scripts/common/Interfaces.js";
 
@@ -9,6 +10,7 @@ describe("HistoryModel", () => {
     let mockSettingsStorage: IAsyncSettingsStorage;
     let dictionaryFactory: DictionaryFactory;
     let languageManager: LanguageManager;
+    let settings: Settings;
     let historyModel: HistoryModel;
 
     beforeEach(async () => {
@@ -17,7 +19,8 @@ describe("HistoryModel", () => {
         dictionaryFactory = new DictionaryFactory();
         languageManager = new LanguageManager(mockSettingsStorage, dictionaryFactory);
         await languageManager.waitForInitialization();
-        historyModel = new HistoryModel(mockMessageService, languageManager);
+        settings = new Settings(mockSettingsStorage);
+        historyModel = new HistoryModel(mockMessageService, languageManager, settings);
     });
 
     it("should report the reader's own Language Direction, used to pick the opening tab", async () => {
@@ -68,6 +71,26 @@ describe("HistoryModel", () => {
             const rows = await historyModel.loadHistory(ALL_DIRECTIONS);
 
             expect(rows.length).toBe(1);
+        });
+    });
+
+    describe("recording", () => {
+        it("should report recording as on until it has been turned off", async () => {
+            expect(await historyModel.getRecordHistory()).toBe(true);
+
+            await settings.setRecordHistory(false);
+
+            expect(await historyModel.getRecordHistory()).toBe(false);
+        });
+
+        it("should turn recording back on, so the History page need not send the reader to Options", async () => {
+            await settings.setRecordHistory(false);
+
+            await historyModel.setRecordHistory(true);
+
+            // Read back through Settings: the service worker reads the same key when
+            // it decides whether to store the next lookup.
+            expect(await settings.getRecordHistory()).toBe(true);
         });
     });
 


### PR DESCRIPTION
The History page is where a reader notices the setting - it is the list that stops growing - but it said nothing about it, and the empty state told them to Alt + double-click "to start building your list", advice that builds nothing while recording is off.

Empty and off now reads "Recording is off" with a button that ends it; a list that already has rows carries the same message as a notice above the table, so today's missing words have an explanation. The button writes the same recordHistory key the service worker reads per lookup, so the next word is stored without either page reloading.