### PR TITLE
fix: implement offscreen audio playback for pronunciation clips

### DIFF
--- a/DOCKER_TESTING.md
+++ b/DOCKER_TESTING.md
@@ -47,9 +47,10 @@ docker run --rm \
 
 The Docker setup:
 1. Uses the official Playwright Docker image as base
-2. Installs Xvfb (X Virtual Framebuffer) for virtual display support
+2. Installs Xvfb (X Virtual Framebuffer), which the suite no longer needs - it runs
+   headless - but which is what lets you run it headed inside the container
 3. Builds the extension from source
-4. Runs tests with a virtual display (required for Chrome extensions)
+4. Runs the tests headless, on the full Chromium build (`channel: "chromium"`)
 5. Exports test results and reports as volumes
 
 ## Test Results
@@ -68,11 +69,14 @@ The GitHub Actions workflow (`.github/workflows/test.yml`) automatically:
 ## Troubleshooting
 
 ### Tests fail with display errors
-- Ensure Xvfb is running (handled automatically in the Docker container)
-- Check that the DISPLAY environment variable is set to `:99`
+- The suite runs headless, so a display error means something asked for a window -
+  a `--headed` run, or `channel: "chromium"` missing from the Playwright config
+- For a headed run inside the container: Xvfb is started for you, and DISPLAY is `:99`
 
 ### Extension not loading
 - Verify the extension was built successfully (`dist/` folder exists)
+- Check `channel: "chromium"` is still in `playwright.config.ts`: without it a
+  headless run gets the headless shell, which loads no extensions at all
 - Check that the extension path is correct in the test fixtures
 
 ### Network timeouts

--- a/agents.md
+++ b/agents.md
@@ -744,7 +744,7 @@ npm run lint             # Run ESLint on src/**/*.{ts,js}
 npm run lint:fix         # ESLint with auto-fix
 npm run test             # Run unit tests with Vitest (no browser needed)
 npm run test:watch       # Vitest in watch mode
-npm run test:e2e         # Playwright e2e tests (requires build + headed Chrome)
+npm run test:e2e         # Playwright e2e tests (requires a build; runs headless)
 npm run dev              # Build then watch
 ```
 
@@ -791,7 +791,10 @@ npm run dev              # Build then watch
 ### E2E Tests (`npm run test:e2e`)
 
 - **Requires a full build first**: `npm run build`
-- Chrome extensions only work in **headed Chromium** — do not set `headless: true`
+- Chrome extensions need the **full Chromium build**: `channel: "chromium"` in
+  `playwright.config.ts`. Headless is fine with it, and is the default; without it a
+  headless run gets the headless shell, which loads no extensions at all. Use
+  `npm run test:e2e:headed` when you want to watch a run
 - Test files: `tests/e2e/smoke.spec.ts`; shared fixtures: `tests/e2e/fixtures.ts`
 - A local static server (port 3456) is started automatically by Playwright config
 - Run e2e tests after UI changes, manifest changes, or content script changes
@@ -818,7 +821,7 @@ dist/temp/              # Intermediate tsc output — not the final product
 - **Never edit `dist/`** — it is fully regenerated on every build; edit `src/` instead
 - **Background service worker** has no `localStorage` and no DOM — use `chrome.storage.local` through `ChromeStorageAdapter`
 - **esbuild bundles each entry point independently** — circular imports across entry-point boundaries will silently fail at runtime
-- **E2E tests require headed Chrome** — extensions cannot be loaded in headless mode
+- **E2E tests need `channel: "chromium"`** — the headless shell Playwright uses otherwise cannot load an extension, which is why headless runs were once thought impossible
 - **Adding a new page or script**: register its entry point in `build.js` esbuild config, add HTML to `src/html/`, CSS to `src/css/`
 
 ---

--- a/agents.md
+++ b/agents.md
@@ -71,11 +71,18 @@ The Lexin Dictionary Chrome Extension is a Swedish-to-multilingual dictionary to
 - Returns `{translation: string, error: string}` object
 - Always resolves (never rejects) to ensure UI gets feedback
 
+#### `playAudio(url): Promise<void>`
+- Opens the Offscreen Document on demand and hands it the pronunciation clip
+- In this path because only the worker can open that document — and only that
+  document can load the clip free of the host page's Content Security Policy
+- See [docs/adr/0004-offscreen-audio-playback.md](docs/adr/0004-offscreen-audio-playback.md)
+
 #### `initialize(): void`
 - Registers message handlers:
   - `getTranslation`: Handles translation requests
   - `loadHistory`: Retrieves translation history for a language
   - `clearHistory`: Clears history for a language
+  - `playAudio`: Plays a pronunciation clip in the Offscreen Document
 - Sets up communication bridge between content scripts and translation logic
 
 ---
@@ -580,6 +587,9 @@ Animation utilities:
      - `background-main.ts` → Service worker
      - `content-main.ts` → Content script
      - `popup-main.ts`, `options-main.ts`, `history-main.ts`, `help-main.ts` → UI pages
+     - `offscreen-main.ts` → Offscreen Document, where pronunciation clips are played
+       (a web page's CSP blocks them anywhere else; see
+       [docs/adr/0004-offscreen-audio-playback.md](docs/adr/0004-offscreen-audio-playback.md))
    - Bundles dependencies and polyfills
 
 3. **Asset Copying** (`npm run build:copy`)

--- a/build.js
+++ b/build.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 /**
- * The six surfaces, named as they sit under scripts/. Each is bundled into a
+ * The seven surfaces, named as they sit under scripts/. Each is bundled into a
  * self-contained IIFE at dist/scripts/<name>.js - which is why nothing needs to be
  * listed in web_accessible_resources. See ManifestTests.
  *
@@ -20,7 +20,8 @@ const surfaces = [
   'options/options-main',
   'history/history-main',
   'help-main',
-  'content/content-main'
+  'content/content-main',
+  'offscreen/offscreen-main'
 ];
 
 const compiledEntryPoints = surfaces.map((surface) => `dist/temp/scripts/${surface}.js`);

--- a/docs/adr/0004-offscreen-audio-playback.md
+++ b/docs/adr/0004-offscreen-audio-playback.md
@@ -78,6 +78,32 @@ and `OffscreenAudioPlayer` is built around that:
   response there is no way to tell a document that took the clip from one that was
   no longer there.
 
+## The extension now requires Chrome 116
+
+`chrome.offscreen` is Chrome 109+, but `chrome.runtime.getContexts` - which the
+player asks whether a document is already open - is Chrome 116+. On 109 through 115
+the two disagree: offscreen documents exist, the check throws, and every LYSSNA
+click fails before `createDocument` is reached. That is worse than not fixing the
+bug, because it takes the button down on the CSP-free pages and in the Action Popup
+where it still worked. `minimum_chrome_version: "116"` is what closes that gap, and
+`ManifestTests` pins it.
+
+The alternative was to carry a fallback: skip the check and treat an unanswered
+message as "no document open", which needs no API newer than 109. It was not worth
+it. Chrome 116 shipped in August 2023, and the population it excludes is dominated
+by machines pinned to Chrome 109 for good - Windows 7 and 8.1, macOS 10.13 and
+earlier - which will not reach any floor we could reasonably pick.
+
+What those users see is the gentlest failure available: an install already in place
+keeps working on the last version it can run, and simply stops receiving updates.
+Chrome does this silently, which is the part worth knowing - nothing tells them, and
+nothing here can. New installs get "Not compatible" in the store instead of a button.
+
+Raise the floor only alongside an API that needs it. `chrome.action.openPopup` is
+Chrome 127+ and deliberately does not count: `BackgroundWorker.openActionPopup`
+degrades to a warning when it is missing, which is the pattern to prefer whenever
+the feature can survive without the API.
+
 ## Consequences
 
 - `LinkAdapter` constructs no media element. If a future change reintroduces one in

--- a/docs/adr/0004-offscreen-audio-playback.md
+++ b/docs/adr/0004-offscreen-audio-playback.md
@@ -1,0 +1,96 @@
+# Play pronunciation clips in an Offscreen Document
+
+The LYSSNA button worked in the Action Popup and on plain pages, and did nothing on
+svt.se. The console on svt.se said why:
+
+```
+Loading media from 'https://lexin.nada.kth.se/sound/v2/390998_2.mp3' violates the
+following Content Security Policy directive: "default-src blob: data: ... 'self'
+'unsafe-eval' 'unsafe-inline'". Note that 'media-src' was not explicitly set, so
+'default-src' is used as a fallback. The action has been blocked.
+```
+
+`LinkAdapter` played the clip with `new Audio(url)`. A content script runs in an
+isolated world but shares the page's *document*, so the media element it creates is
+the page's element and the clip is the page's subresource - checked against the
+page's Content Security Policy, not the extension's. Any site whose `default-src`
+(or `media-src`) omits `lexin.nada.kth.se` blocks it, which is every site that sets
+a policy at all. 8sidor.se sets none, so the button worked there; svt.se sets a
+strict one, so it did not. The mixed-content fix in ADR 0003 was a different
+blocker on the same line of code and did not touch this one.
+
+The clip now plays in an Offscreen Document: `LinkAdapter` sends `playAudio` to the
+service worker, which opens `html/offscreen.html` on demand and forwards the URL to
+it. An Offscreen Document is an extension page, so `script-src 'self'; object-src
+'self'` - the extension's own policy, which restricts no media at all - is what
+governs the load. No web page has a say.
+
+## Why not the alternatives
+
+- **Fetch the bytes and play them through the Web Audio API in the page.** CSP does
+  not govern an `AudioBuffer`, so this works, and it keeps the sound attached to the
+  reader's tab where the tab's mute control can reach it. It costs a base64 round
+  trip of every clip through the message bus, and it makes playback depend on
+  `Access-Control-Allow-Origin` on the sound host, which is the dependency ADR 0003
+  already flags as the live risk for lookups. A media element in an extension page
+  needs no CORS at all.
+- **Load the clip in an iframe pointing at an extension page.** The frame would need
+  `web_accessible_resources`, which `ManifestTests` forbids, and the page's
+  `frame-src` would get a vote anyway.
+- **Play it in the Action Popup.** The popup is not open when the card is.
+
+## What it costs
+
+- **A permission.** `permissions` is now `["storage", "offscreen"]`. Chrome shows no
+  install warning for either, and the all-sites content script already produces the
+  broadest warning there is, so no existing user is asked to re-consent. The store
+  submission form may still ask what it is for; the answer is in
+  `docs/store-listing.md`.
+- **A seventh surface to build.** `offscreen/offscreen-main` in `build.js`, and
+  `src/html/offscreen.html`, which is markup-free: the script creates the `<audio>`
+  element.
+- **The sound is no longer the tab's.** The reader's tab does not show the speaker
+  icon while a clip plays, tab mute does not silence it, and a clip started from the
+  Action Popup now finishes after the popup closes rather than being cut off. The
+  last one is an improvement; the first two are a genuine, if small, loss.
+- **One code path for both surfaces that render a translation.** The Action Popup
+  goes through the worker too, though its own document could have played the clip
+  itself. Two paths would mean the popup quietly covering for a card that is broken -
+  which is exactly how this bug survived: it was only ever reproducible in the card.
+
+## The document's lifetime is Chrome's, not ours
+
+Nothing in this extension closes the Offscreen Document. Chrome closes a document
+created with `AUDIO_PLAYBACK` after 30 seconds of silence, which is exactly the
+policy we would have written, and a reader working through several words pays the
+creation cost once.
+
+The consequence is that "is a document open?" has a different answer on every click,
+and `OffscreenAudioPlayer` is built around that:
+
+- `chrome.runtime.getContexts` decides whether to create one, because
+  `createDocument` rejects when a document already exists.
+- Creation is serialised through a single in-flight promise, so two clicks in quick
+  succession queue behind one creation instead of racing into a rejection.
+- The document can close *between* that check and the message, and the message then
+  lands nowhere. The clip is sent again, exactly once, against a document known to
+  have just been created. This is why `AudioPlayback.play` answers `true`: without a
+  response there is no way to tell a document that took the clip from one that was
+  no longer there.
+
+## Consequences
+
+- `LinkAdapter` constructs no media element. If a future change reintroduces one in
+  code that runs in a content script, it will work on every page the developer
+  happens to test on and fail on the sites readers use.
+- `OffscreenAudioPlayerTests` covers the lifetime rules with a `chrome` double;
+  `tests/e2e/audio-playback.spec.ts` clicks LYSSNA on a fixture page carrying
+  svt.se's policy and asserts the document opens and no violation is raised. That
+  test does not assert a sound is produced: Playwright's Chromium ships without the
+  proprietary decoders, so the clip reaches the document and fails to decode there.
+  Nothing in the suite proves audio is audible - that check stays manual.
+- Images in the dictionary's markup are still the page's subresources, and a strict
+  policy blocks them the same way. Today that is one 11x11 download icon in Lexin's
+  entries, and Folkets' inflection images for words that have them. This ADR does
+  not address that; the fix would be a different mechanism again, since an `<img>`
+  cannot be moved into an Offscreen Document.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -129,9 +129,13 @@ Earlier releases: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/r
   monolingual dictionary, and listing it beside the target languages reads as a bug.
   It gets its own sentence.
 - **The permission warning is addressed head-on.** The manifest requests only
-  `storage`, but the content script's `http://*/*` and `https://*/*` matches still
-  make Chrome say "read and change all your data on websites you visit" at install.
-  Leaving that unexplained costs installs.
+  `storage` and `offscreen` - neither of which Chrome warns about - but the content
+  script's `http://*/*` and `https://*/*` matches still make Chrome say "read and
+  change all your data on websites you visit" at install. Leaving that unexplained
+  costs installs. If the submission form asks what `offscreen` is for: it plays the
+  pronunciation clip, which a web page's Content Security Policy blocks when the
+  in-page card tries to play it itself. See
+  `docs/adr/0004-offscreen-audio-playback.md`.
 - **Check the language list against `LexinDictionary.getSupportedLanguages()` and
   `FolketsDictionary.getSupportedLanguages()`** whenever a dictionary is added.
   Currently 20 via Lexin plus English via Folkets.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,12 +2,15 @@ import { defineConfig } from "@playwright/test";
 
 /**
  * Playwright configuration for Chrome extension E2E testing.
- * 
+ *
  * Note: Chrome extensions require:
  * - Chromium browser (not Firefox or WebKit)
- * - Headed mode (extensions don't work in headless mode)
  * - Persistent context with the extension loaded
- * 
+ * - `channel: "chromium"`, which is what makes headless work: the default
+ *   chromium build for headless runs is the headless shell, which supports no
+ *   extensions at all. The channel runs the full browser in Chrome's newer
+ *   headless mode, where they load normally.
+ *
  * @see https://playwright.dev/docs/chrome-extensions
  */
 export default defineConfig({
@@ -57,12 +60,14 @@ export default defineConfig({
   },
   
   use: {
-    // Browser settings
+    // Browser settings. The channel is load-bearing - see the note above.
     browserName: "chromium",
-    
-    // Chrome extensions don't work in headless mode
-    headless: false,
-    
+    channel: "chromium",
+
+    // Headless by default so a run does not open a window and take focus.
+    // `npm run test:e2e:headed` (or --headed) still gives you one to watch.
+    headless: true,
+
     // Viewport
     viewport: { width: 1280, height: 720 },
     

--- a/src/html/offscreen.html
+++ b/src/html/offscreen.html
@@ -1,0 +1,22 @@
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>Lexin audio</title>
+</head>
+
+<!--
+    Never seen by anyone. The document exists so that pronunciation clips load under
+    the extension's Content Security Policy instead of the policy of whichever site
+    the reader is on - the Translation Card renders inside that page, and a strict
+    default-src there blocks the clip. The <audio> element is created by the script;
+    there is nothing to mark up.
+
+    See docs/adr/0004-offscreen-audio-playback.md.
+-->
+
+<body>
+    <script src="../scripts/offscreen-main.js" type="module"></script>
+</body>
+
+</html>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 3,
   "name": "Lexin dictionary",
   "version": "3.0.0.0",
+  "minimum_chrome_version": "116",
   "description": "Swedish to other languages dictionary. Powered by Lexin and Folkets Lexikon",
   "icons": {
     "16": "icons/icon16.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,8 @@
     "extension_pages": "script-src 'self'; object-src 'self'"
   },
   "permissions": [
-    "storage"
+    "storage",
+    "offscreen"
   ],
   "content_scripts": [
     {

--- a/src/scripts/common/Interfaces.ts
+++ b/src/scripts/common/Interfaces.ts
@@ -58,6 +58,12 @@ export interface IMessageService {
     getSelectedText(): Promise<string>;
     createNewTab(url: string): void;
     openActionPopup(): Promise<void>;
+    playAudio(url: string): Promise<void>;
+}
+
+/** Plays a pronunciation clip. See OffscreenAudioPlayer for the only implementation. */
+export interface IAudioPlayer {
+    play(url: string): Promise<void>;
 }
 
 export interface ITranslationManager {
@@ -119,6 +125,10 @@ export interface OpenActionPopupHandler {
     (): Promise<void>;
 }
 
+export interface PlayAudioHandler {
+    (url: string): Promise<any>;
+}
+
 export interface IMessageHandlers {
     registerGetTranslationHandler(handler: GetTranslationHandler): void ;
     registerLoadHistoryHandler(handler: LoadHistoryHandler): void;
@@ -127,6 +137,8 @@ export interface IMessageHandlers {
     registerRemoveHistoryItemHandler(handler: RemoveHistoryItemHandler): void;
     registerGetSelectionHandler(handler: GetSelectionHandler): void;
     registerOpenActionPopupHandler(handler: OpenActionPopupHandler): void;
+    registerPlayAudioHandler(handler: PlayAudioHandler): void;
+    registerPlayAudioInOffscreenDocumentHandler(handler: PlayAudioHandler): void;
 }
 
 

--- a/src/scripts/common/LinkAdapter.ts
+++ b/src/scripts/common/LinkAdapter.ts
@@ -1,6 +1,11 @@
+import MessageService from "../messaging/MessageService.js";
+
 class LinkAdapter {
 
     private static readonly FOLKETS_BASE = "https://folkets-lexikon.csc.kth.se/folkets/";
+
+    /** Stateless, and the same in every surface that renders a translation. */
+    private static readonly messageService = new MessageService();
 
     /**
      * Both dictionary services still write http:// into the markup they return - into
@@ -9,7 +14,11 @@ class LinkAdapter {
      * on an https:// page the browser blocks them as mixed content: the LYSSNA button
      * plays nothing and the inflection images never appear, while the same card works
      * in the popup. Both hosts serve the identical content over TLS, so upgrading the
-     * scheme is the whole fix.
+     * scheme is the whole fix for mixed content - but it was not the whole fix for the
+     * clip, which the host page's CSP blocked next, over https and all. That one is
+     * settled elsewhere: see docs/adr/0004-offscreen-audio-playback.md. The images
+     * below still load as the page's own subresources and a strict policy still
+     * blocks them.
      */
     private static toSecureUrl(url: string): string {
         return url.replace(/^http:\/\//i, "https://");
@@ -71,14 +80,16 @@ class LinkAdapter {
                         e.stopPropagation();
                         e.stopImmediatePropagation();
                         
-                        // Play audio directly
-                        const audio = new Audio(audioUrl!);
-                        audio.addEventListener("error", (err) => {
-                            console.error("playAudio: Error playing audio", audioUrl, err);
-                        });
-                        audio.play().catch((error) => {
-                            console.error("playAudio: Failed to play audio", audioUrl, error);
-                        });
+                        // Played in the extension's Offscreen Document rather than
+                        // here. An <audio> element created in this context belongs
+                        // to whatever document the card is rendered in - which, in a
+                        // content script, is the host page, whose CSP then decides
+                        // whether the clip may load at all. It usually may not: the
+                        // sites this extension is most used on send a default-src
+                        // that has never heard of lexin.nada.kth.se, and the button
+                        // came up silent there while working in the Action Popup.
+                        // See docs/adr/0004-offscreen-audio-playback.md.
+                        LinkAdapter.messageService.playAudio(audioUrl!);
                     };
                     
                     // Set onclick property directly (harder to override)

--- a/src/scripts/messaging/MessageHandlers.ts
+++ b/src/scripts/messaging/MessageHandlers.ts
@@ -1,6 +1,6 @@
 import { IMessageHandlers, GetTranslationHandler, LoadHistoryHandler, ClearHistoryHandler,
     GetSelectionHandler, OpenActionPopupHandler, LoadHistoryDirectionsHandler,
-    RemoveHistoryItemHandler } from "../common/Interfaces.js";
+    RemoveHistoryItemHandler, PlayAudioHandler } from "../common/Interfaces.js";
 import MessageType from "./MessageType.js";
 import MessageBus from "./MessageBus.js";
 
@@ -45,6 +45,18 @@ class MessageHandlers implements IMessageHandlers{
     registerOpenActionPopupHandler(handler: OpenActionPopupHandler): void {
         MessageBus.Instance.registerHandler(MessageType.openActionPopup, (_args) => {
             return handler();
+        });
+    }
+
+    registerPlayAudioHandler(handler: PlayAudioHandler): void {
+        MessageBus.Instance.registerHandler(MessageType.playAudio, (args: any) => {
+            return handler(args.url);
+        });
+    }
+
+    registerPlayAudioInOffscreenDocumentHandler(handler: PlayAudioHandler): void {
+        MessageBus.Instance.registerHandler(MessageType.playAudioInOffscreenDocument, (args: any) => {
+            return handler(args.url);
         });
     }
 }

--- a/src/scripts/messaging/MessageService.ts
+++ b/src/scripts/messaging/MessageService.ts
@@ -38,6 +38,15 @@ class MessageService implements IMessageService{
         MessageBus.Instance.createNewTab(url);
     }
 
+    playAudio(url: string): Promise<void> {
+        // Playback lives in the Offscreen Document the worker owns, never in the
+        // calling context: a Translation Card renders inside the page, so an <audio>
+        // element it created would load the clip under the page's Content Security
+        // Policy - and svt.se, to name one, has no media-src for lexin.nada.kth.se.
+        // See docs/adr/0004-offscreen-audio-playback.md.
+        return MessageBus.Instance.sendMessage(MessageType.playAudio, {url: url});
+    }
+
     openActionPopup(): Promise<void> {
         // Only the service worker can open the Action Popup, so this is a message
         // rather than a direct call - the Translation Card's expand button runs in a

--- a/src/scripts/messaging/MessageType.ts
+++ b/src/scripts/messaging/MessageType.ts
@@ -5,7 +5,19 @@ enum MessageType {
     getSelection,
     openActionPopup,
     getHistoryDirections,
-    removeHistoryItem
+    removeHistoryItem,
+    /** Any surface -> the service worker: play this pronunciation clip. */
+    playAudio,
+    /**
+     * The service worker -> the Offscreen Document, which is the only context that
+     * can both hold an <audio> element and load it free of a web page's CSP.
+     *
+     * Kept apart from playAudio because chrome.runtime.sendMessage reaches every
+     * extension context except the sender: were it one type, a clip played from the
+     * Action Popup would arrive at the worker *and* at an already-open Offscreen
+     * Document, and the worker's forward would play it a second time.
+     */
+    playAudioInOffscreenDocument
 }
 
 export default MessageType;

--- a/src/scripts/offscreen/AudioPlayback.ts
+++ b/src/scripts/offscreen/AudioPlayback.ts
@@ -1,0 +1,49 @@
+import { IMessageHandlers } from "../common/Interfaces.js";
+
+/**
+ * The Offscreen Document's whole job: hold the <audio> element the service worker
+ * cannot, and load clips under the extension's CSP rather than a web page's.
+ *
+ * Nothing here closes the document. Chrome does it, 30 seconds after the last sound
+ * an AUDIO_PLAYBACK document made - which is both the reason the page asks for that
+ * reason and why a reader who plays several words in a row pays the creation cost
+ * once. See docs/adr/0004-offscreen-audio-playback.md.
+ */
+class AudioPlayback {
+
+    private messageHandlers: IMessageHandlers;
+    private current: HTMLAudioElement | null = null;
+
+    constructor(messageHandlers: IMessageHandlers) {
+        this.messageHandlers = messageHandlers;
+    }
+
+    /**
+     * Resolves true once playback has started - the worker reads that as "the
+     * document is alive and took the clip", and asks again if it never arrives.
+     */
+    async play(url: string): Promise<boolean> {
+        // A second LYSSNA click replaces the first clip rather than talking over it.
+        if (this.current) {
+            this.current.pause();
+        }
+
+        const audio = new Audio(url);
+        this.current = audio;
+        try {
+            await audio.play();
+        } catch (error) {
+            // A clip that will not play is worth a line in the Offscreen Document's
+            // console, but the answer still goes back: the document did its part,
+            // and a retry would only fail the same way.
+            console.error("playAudio: failed to play", url, error);
+        }
+        return true;
+    }
+
+    initialize(): void {
+        this.messageHandlers.registerPlayAudioInOffscreenDocumentHandler((url) => this.play(url));
+    }
+}
+
+export default AudioPlayback;

--- a/src/scripts/offscreen/offscreen-main.ts
+++ b/src/scripts/offscreen/offscreen-main.ts
@@ -1,0 +1,1 @@
+import "./offscreen.js";

--- a/src/scripts/offscreen/offscreen.ts
+++ b/src/scripts/offscreen/offscreen.ts
@@ -1,0 +1,5 @@
+import MessageHandlers from "../messaging/MessageHandlers.js";
+import AudioPlayback from "./AudioPlayback.js";
+
+const audioPlayback = new AudioPlayback(new MessageHandlers());
+audioPlayback.initialize();

--- a/src/scripts/worker/BackgroundWorker.ts
+++ b/src/scripts/worker/BackgroundWorker.ts
@@ -1,4 +1,5 @@
-import { IHistoryManager, ITranslation, ITranslationManager, IMessageHandlers } from "../common/Interfaces.js";
+import { IHistoryManager, ITranslation, ITranslationManager, IMessageHandlers,
+    IAudioPlayer } from "../common/Interfaces.js";
 import TranslationDirection from "../dictionary/TranslationDirection.js";
 
 class BackgroundWorker {
@@ -6,11 +7,14 @@ class BackgroundWorker {
     private historyManager: IHistoryManager;
     private translationManager: ITranslationManager;
     private messageHandlers: IMessageHandlers;
+    private audioPlayer: IAudioPlayer;
 
-    constructor(historyManager : IHistoryManager, translationManager: ITranslationManager, messageHandlers: IMessageHandlers) {
+    constructor(historyManager : IHistoryManager, translationManager: ITranslationManager,
+                messageHandlers: IMessageHandlers, audioPlayer: IAudioPlayer) {
         this.historyManager = historyManager;
         this.translationManager = translationManager;
         this.messageHandlers = messageHandlers;
+        this.audioPlayer = audioPlayer;
     }
 
     getTranslation(word: string, direction: TranslationDirection): Promise<ITranslation> {
@@ -44,6 +48,18 @@ class BackgroundWorker {
         }
     }
 
+    /**
+     * Plays a pronunciation clip on behalf of whichever surface was clicked.
+     *
+     * The worker is in this path for one reason: only it can open the Offscreen
+     * Document where the clip is allowed to load. A Translation Card that played the
+     * clip itself would do so under the host page's CSP, which on a site like svt.se
+     * blocks it. See docs/adr/0004-offscreen-audio-playback.md.
+     */
+    playAudio(url: string): Promise<void> {
+        return this.audioPlayer.play(url);
+    }
+
     initialize(): void {
         this.messageHandlers.registerGetTranslationHandler((word, direction) => this.getTranslation(word, direction));
         this.messageHandlers.registerLoadHistoryHandler((langDirection) => this.historyManager.getHistory(langDirection));
@@ -52,6 +68,7 @@ class BackgroundWorker {
         this.messageHandlers.registerRemoveHistoryItemHandler(
             (langDirection, word, added) => this.historyManager.removeItem(langDirection, word, added));
         this.messageHandlers.registerOpenActionPopupHandler(() => this.openActionPopup());
+        this.messageHandlers.registerPlayAudioHandler((url) => this.playAudio(url));
     }
 }
 

--- a/src/scripts/worker/OffscreenAudioPlayer.ts
+++ b/src/scripts/worker/OffscreenAudioPlayer.ts
@@ -1,0 +1,96 @@
+import { IAudioPlayer } from "../common/Interfaces.js";
+import MessageBus from "../messaging/MessageBus.js";
+import MessageType from "../messaging/MessageType.js";
+
+/**
+ * Plays a pronunciation clip through an Offscreen Document, creating one on demand.
+ *
+ * A service worker has no <audio> element and every other context this extension
+ * runs in is a web page - either literally, for the Translation Card, or an
+ * extension page. The card's context is the problem: a media element it creates
+ * belongs to the host page's document, so the clip loads under *that page's* CSP,
+ * and a site with a strict default-src blocks it outright. An Offscreen Document is
+ * an extension page, so the clip loads under the extension's own policy no matter
+ * which site the reader is on. See docs/adr/0004-offscreen-audio-playback.md.
+ */
+class OffscreenAudioPlayer implements IAudioPlayer {
+
+    private static readonly PAGE = "html/offscreen.html";
+
+    /**
+     * In-flight createDocument, if any. Chrome allows one Offscreen Document per
+     * extension and rejects a second createDocument, so two clicks in quick
+     * succession have to queue behind one creation rather than race into it.
+     */
+    private creating: Promise<void> | null = null;
+
+    async play(url: string): Promise<void> {
+        if (await this.request(url)) {
+            return;
+        }
+        // Nobody answered. Chrome closes an AUDIO_PLAYBACK document after 30 seconds
+        // of silence, and it can do so between the check below and the message going
+        // out - so the one thing worth doing is asking again against a document we
+        // know was just created. Exactly one retry: a second silence is a real
+        // failure, not a race.
+        if (!await this.request(url)) {
+            console.error("playAudio: the Offscreen Document did not answer", url);
+        }
+    }
+
+    /** Sends the clip to the Offscreen Document. False when nothing answered. */
+    private async request(url: string): Promise<boolean> {
+        try {
+            await this.ensureDocument();
+        } catch (error) {
+            console.error("playAudio: could not open the Offscreen Document", error);
+            return false;
+        }
+        const played = await MessageBus.Instance.sendMessage(
+            MessageType.playAudioInOffscreenDocument, {url: url});
+        return played === true;
+    }
+
+    /**
+     * Serialised through `creating` whether or not it ends up creating anything, so
+     * that a caller arriving mid-creation waits for the same promise instead of
+     * seeing "no document" and asking for a second one.
+     */
+    private ensureDocument(): Promise<void> {
+        if (!this.creating) {
+            this.creating = this.createDocument().finally(() => {
+                this.creating = null;
+            });
+        }
+        return this.creating;
+    }
+
+    private async createDocument(): Promise<void> {
+        if (await this.hasDocument()) {
+            return;
+        }
+        try {
+            await chrome.offscreen.createDocument({
+                url: OffscreenAudioPlayer.PAGE,
+                reasons: [chrome.offscreen.Reason.AUDIO_PLAYBACK],
+                justification: "Play the pronunciation clip behind the dictionary's LYSSNA button."
+            });
+        } catch (error) {
+            // A document that appeared between the check and the call - another
+            // service worker instance got there first - is the state we wanted.
+            if (!await this.hasDocument()) {
+                throw error;
+            }
+        }
+    }
+
+    private async hasDocument(): Promise<boolean> {
+        const contexts = await chrome.runtime.getContexts({
+            contextTypes: ["OFFSCREEN_DOCUMENT" as chrome.runtime.ContextType],
+            documentUrls: [chrome.runtime.getURL(OffscreenAudioPlayer.PAGE)]
+        });
+        return contexts.length > 0;
+    }
+}
+
+export default OffscreenAudioPlayer;

--- a/src/scripts/worker/background.ts
+++ b/src/scripts/worker/background.ts
@@ -10,6 +10,7 @@ import { createChromeStorage } from "../common/ChromeStorageAdapter.js";
 import FetchLoader from "../dictionary/FetchLoader.js";
 import LexinDictionary from "../dictionary/LexinDictionary.js";
 import FolketsDictionary from "../dictionary/FolketsDictionary.js";
+import OffscreenAudioPlayer from "./OffscreenAudioPlayer.js";
 
 // Initialize storage adapters for service worker context
 // Service workers don't have access to localStorage, so we use chrome.storage
@@ -34,7 +35,8 @@ try {
     const historyManager = new HistoryManager(translationParser, storage);
     const translationManager = new TranslationManager(historyManager, dictionaryFactory, languageManager, settings);
     const messageHandlers = new MessageHandlers();
-    const backgroundWorker = new BackgroundWorker(historyManager, translationManager, messageHandlers);
+    const backgroundWorker = new BackgroundWorker(historyManager, translationManager, messageHandlers,
+        new OffscreenAudioPlayer());
     
     backgroundWorker.initialize();
     

--- a/tests/e2e/audio-playback.spec.ts
+++ b/tests/e2e/audio-playback.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect, ExtensionHelpers } from "./fixtures";
+import type { Page, Worker } from "@playwright/test";
+
+/**
+ * Guards the LYSSNA button against the reader's page.
+ *
+ * The card used to create its own <audio> element, which - in a content script -
+ * belongs to the *host page's* document. The clip is then that page's subresource,
+ * and any site with a strict default-src blocks it: the button worked in the Action
+ * Popup and on plain pages, and came up silent on svt.se. Playback moved into an
+ * Offscreen Document, an extension page, where the extension's own policy applies.
+ * See docs/adr/0004-offscreen-audio-playback.md.
+ *
+ * The fixture page carries svt.se's policy in a meta tag. What is asserted is that
+ * the clip left the page - no violation, and an Offscreen Document open on the other
+ * side - not that a sound came out: Playwright's Chromium ships without the
+ * proprietary decoders, so the clip that reaches the document will not decode there.
+ */
+
+const CSP_PAGE = "http://localhost:3456/strict-csp.html";
+
+/** Lexin's swe_swe definition of "bil", the fixture's test word. */
+const EXPECTED_TRANSLATION = "ett fordon för ett litet antal personer";
+
+/** Alt+Double click the fixture's test word and wait for the card to fill in. */
+async function summonCard(page: Page) {
+    const testWord = page.locator("#test-word");
+    await expect(testWord).toBeVisible();
+    const box = await testWord.boundingBox();
+
+    await page.keyboard.down("Alt");
+    await page.mouse.dblclick(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.keyboard.up("Alt");
+
+    // Locators pierce the open shadow root the card renders in.
+    const content = page.locator(".lexinTranslationContent");
+    await expect(content).toBeVisible({ timeout: 15000 });
+    await expect(content).toContainText(EXPECTED_TRANSLATION, { timeout: 15000 });
+}
+
+/** The Offscreen Documents this extension currently has open, by URL. */
+async function offscreenDocuments(worker: Worker): Promise<string[]> {
+    const contexts = await worker.evaluate(async () => {
+        const found = await chrome.runtime.getContexts({
+            contextTypes: ["OFFSCREEN_DOCUMENT" as chrome.runtime.ContextType]
+        });
+        return found.map((context) => context.documentUrl ?? "");
+    });
+    return contexts;
+}
+
+test.describe("Pronunciation playback", () => {
+
+    test.beforeEach(async ({ context, extensionId }) => {
+        // swe_swe both keeps the assertion independent of the stored language and
+        // gives the entry a LYSSNA button to click.
+        await ExtensionHelpers.setLanguage(context, extensionId, "swe_swe");
+    });
+
+    test("plays a clip from a page whose CSP forbids it", async ({ context }) => {
+        const worker = context.serviceWorkers()[0] ?? await context.waitForEvent("serviceworker");
+        const page = await context.newPage();
+
+        // Both halves of the old failure. The event is what the page itself sees; the
+        // console line is what the reader saw in devtools and reported.
+        const violations: string[] = [];
+        const consoleErrors: string[] = [];
+        page.on("console", (message) => {
+            if (message.type() === "error") {
+                consoleErrors.push(message.text());
+            }
+        });
+        await page.goto(CSP_PAGE);
+        await page.waitForLoadState("domcontentloaded");
+        await page.exposeFunction("reportViolation", (blocked: string) => violations.push(blocked));
+        await page.evaluate(() => {
+            document.addEventListener("securitypolicyviolation",
+                (event) => (window as any).reportViolation(event.blockedURI));
+        });
+
+        await summonCard(page);
+        expect(await offscreenDocuments(worker)).toHaveLength(0);
+
+        await page.locator(".lexinTranslationContent").getByText("LYSSNA").first().click();
+
+        // The document is opened on demand, so its arrival is the proof the click
+        // took the new path rather than reaching for an <audio> element in the page.
+        await expect.poll(() => offscreenDocuments(worker), { timeout: 10000 })
+            .toEqual([expect.stringContaining("/html/offscreen.html")]);
+
+        // Narrowed to the clip rather than "no violation at all": Lexin's markup also
+        // carries an <img> from the same host, which this page blocks too. That is a
+        // download icon failing to draw, not a feature failing to work.
+        expect(violations.filter((blocked) => blocked.includes("/sound/"))).toEqual([]);
+        expect(consoleErrors.filter((text) =>
+            text.includes("Content Security Policy") && text.includes("/sound/"))).toEqual([]);
+
+        await page.close();
+    });
+
+    test("keeps one document for a reader working through several words", async ({ context }) => {
+        // Chrome allows a single Offscreen Document per extension and rejects a
+        // second createDocument, so a repeated click must find the one already open.
+        const worker = context.serviceWorkers()[0] ?? await context.waitForEvent("serviceworker");
+        const page = await context.newPage();
+        await page.goto(CSP_PAGE);
+        await page.waitForLoadState("domcontentloaded");
+        await summonCard(page);
+
+        const listen = page.locator(".lexinTranslationContent").getByText("LYSSNA").first();
+        await listen.click();
+        await expect.poll(() => offscreenDocuments(worker), { timeout: 10000 }).toHaveLength(1);
+        await listen.click();
+        await listen.click();
+
+        expect(await offscreenDocuments(worker)).toHaveLength(1);
+
+        await page.close();
+    });
+});

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -27,9 +27,14 @@ export const test = base.extend<{
   // Override the default context to load the extension
   // Playwright throws unless the first argument is an object destructuring pattern.
   // eslint-disable-next-line no-empty-pattern
-  context: async ({ }, use) => {
+  // headless and channel come from the config's `use` block, so `--headed` still
+  // opens a window for debugging. Both have to be passed through by hand: an
+  // extension needs launchPersistentContext, which takes its own options rather
+  // than reading the ones Playwright would apply to a browser it launched itself.
+  context: async ({ headless, channel }, use) => {
     const context = await chromium.launchPersistentContext("", {
-      headless: false, // Extensions require headed mode
+      channel,
+      headless,
       args: [
         `--disable-extensions-except=${EXTENSION_PATH}`,
         `--load-extension=${EXTENSION_PATH}`,

--- a/tests/e2e/permissions.spec.ts
+++ b/tests/e2e/permissions.spec.ts
@@ -22,7 +22,7 @@ const SELECTED_WORD = "bil";
 
 test.describe("Shipped permission surface", () => {
 
-  test("loaded extension requests only the storage permission", async ({ context, extensionId }) => {
+  test("loaded extension requests only the storage and offscreen permissions", async ({ context, extensionId }) => {
     const page = await context.newPage();
     await page.goto(`chrome-extension://${extensionId}/html/popup.html`);
 
@@ -30,7 +30,10 @@ test.describe("Shipped permission surface", () => {
     // stale or hand-edited build is caught too - ManifestTests covers source.
     const manifest = await page.evaluate(() => chrome.runtime.getManifest());
 
-    expect(manifest.permissions).toEqual(["storage"]);
+    // offscreen is what lets a pronunciation clip load under the extension's CSP
+    // instead of the reader's page. Neither permission warns the user at install.
+    // See docs/adr/0004-offscreen-audio-playback.md.
+    expect(manifest.permissions).toEqual(["storage", "offscreen"]);
     expect(manifest.web_accessible_resources).toBeUndefined();
 
     await page.close();

--- a/tests/e2e/test-pages/strict-csp.html
+++ b/tests/e2e/test-pages/strict-csp.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Strict CSP Test Page</title>
+
+    <!--
+        The policy below is svt.se's, trimmed to the parts that decide the outcome:
+        a default-src that lists the site's own media hosts, and no media-src at all,
+        so media falls back to default-src. lexin.nada.kth.se is not in it - and
+        neither dictionary host would be in any news site's policy.
+
+        A Translation Card renders inside this document, so an <audio> element the
+        card created would be *this page's* subresource and the policy would block
+        the clip. Playback happens in the extension's Offscreen Document instead.
+        See docs/adr/0004-offscreen-audio-playback.md.
+
+        Declared in a meta tag rather than a header because the fixtures are served
+        by `npx serve`, which sends no headers of its own; a meta-declared policy is
+        enforced on subresource loads exactly the same way.
+    -->
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src blob: data: https://*.svt.se https://www.svtstatic.se 'self' 'unsafe-inline'">
+
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 50px;
+            font-size: 18px;
+            line-height: 2;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        #test-word {
+            font-size: 24px;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <h1>Nyheter</h1>
+
+    <p>
+        En <span id="test-word">bil</span> är ett fordon för transport.
+        Stockholm är Sveriges största stad.
+    </p>
+</body>
+</html>

--- a/tests/unit/BackgroundWorkerTests.ts
+++ b/tests/unit/BackgroundWorkerTests.ts
@@ -3,7 +3,8 @@ import TranslationDirection from "../../src/scripts/dictionary/TranslationDirect
 import {
     FakeHistoryManager,
     FakeTranslationManager,
-    FakeMessageHandlers
+    FakeMessageHandlers,
+    FakeAudioPlayer
 } from "./util/fakes.js";
 
 describe("BackgroundWorker", () => {
@@ -11,12 +12,15 @@ describe("BackgroundWorker", () => {
     let fakeHistoryManager: FakeHistoryManager;
     let fakeTranslationManager: FakeTranslationManager;
     let fakeMessageHandlers: FakeMessageHandlers;
+    let fakeAudioPlayer: FakeAudioPlayer;
 
     beforeEach(() => {
         fakeHistoryManager = new FakeHistoryManager();
         fakeTranslationManager = new FakeTranslationManager();
         fakeMessageHandlers = new FakeMessageHandlers();
-        backgroundWorker = new BackgroundWorker(fakeHistoryManager, fakeTranslationManager, fakeMessageHandlers);
+        fakeAudioPlayer = new FakeAudioPlayer();
+        backgroundWorker = new BackgroundWorker(fakeHistoryManager, fakeTranslationManager, fakeMessageHandlers,
+            fakeAudioPlayer);
     });
 
     describe("getTranslation", () => {
@@ -73,6 +77,24 @@ describe("BackgroundWorker", () => {
         });
     });
 
+    describe("playAudio", () => {
+        // The clip cannot be played where it was clicked: a Translation Card lives in
+        // the host page's document, so its CSP decides whether lexin.nada.kth.se may
+        // be loaded at all. See docs/adr/0004-offscreen-audio-playback.md.
+        it("should hand the clip to the audio player", async () => {
+            await backgroundWorker.playAudio("https://lexin.nada.kth.se/sound/v2/390998_2.mp3");
+
+            expect(fakeAudioPlayer.playedUrls).toEqual(["https://lexin.nada.kth.se/sound/v2/390998_2.mp3"]);
+        });
+
+        it("should answer the caller once playback has started", async () => {
+            // The Translation Card does not await this - but the message bus does,
+            // and a promise that never settles leaves a port open on every click.
+            await expect(backgroundWorker.playAudio("https://lexin.nada.kth.se/a.mp3"))
+                .resolves.toBeUndefined();
+        });
+    });
+
     it("initialize should register handlers", () => {
         backgroundWorker.initialize();
 
@@ -82,5 +104,6 @@ describe("BackgroundWorker", () => {
         expect(fakeMessageHandlers.loadHistoryDirectionsHandler).not.toBeNull();
         expect(fakeMessageHandlers.removeHistoryItemHandler).not.toBeNull();
         expect(fakeMessageHandlers.openActionPopupHandler).not.toBeNull();
+        expect(fakeMessageHandlers.playAudioHandler).not.toBeNull();
     });
 });

--- a/tests/unit/ManifestTests.ts
+++ b/tests/unit/ManifestTests.ts
@@ -14,8 +14,13 @@ import manifest from "../../src/manifest.json";
  */
 describe("manifest permissions", () => {
 
-    it("should request only the storage permission", () => {
-        expect(manifest.permissions).toEqual(["storage"]);
+    it("should request only the storage and offscreen permissions", () => {
+        // offscreen buys the one thing nothing else can: a document that is an
+        // extension page, so a pronunciation clip loads under the extension's CSP
+        // rather than under the CSP of whichever site the reader is on. Neither
+        // permission shows the user a warning at install.
+        // See docs/adr/0004-offscreen-audio-playback.md.
+        expect(manifest.permissions).toEqual(["storage", "offscreen"]);
     });
 
     it("should not request the tabs permission", () => {

--- a/tests/unit/ManifestTests.ts
+++ b/tests/unit/ManifestTests.ts
@@ -43,6 +43,21 @@ describe("manifest permissions", () => {
         expect(manifest).not.toHaveProperty("host_permissions");
     });
 
+    it("should require the Chrome that has every API it calls", () => {
+        // 116 is where chrome.runtime.getContexts arrives, and OffscreenAudioPlayer
+        // asks it whether a document is already open. Offscreen documents themselves
+        // go back to 109, so on 109-115 the LYSSNA button would throw on every click
+        // - including on the pages where it used to work. Declaring the floor is what
+        // keeps that from shipping: an older Chrome stays on the last version it can
+        // run, silently, rather than updating into a broken button.
+        //
+        // Raise this only alongside an API that needs it. chrome.action.openPopup is
+        // Chrome 127+ and deliberately not counted: BackgroundWorker degrades when it
+        // is missing, so it does not set a floor. See
+        // docs/adr/0004-offscreen-audio-playback.md.
+        expect(manifest.minimum_chrome_version).toBe("116");
+    });
+
     it("should not expose any resource to web pages", () => {
         // Every entry point is bundled into a self-contained IIFE and loaded
         // either as a content script or from an extension page, so no script

--- a/tests/unit/OffscreenAudioPlayerTests.ts
+++ b/tests/unit/OffscreenAudioPlayerTests.ts
@@ -1,0 +1,150 @@
+import OffscreenAudioPlayer from "../../src/scripts/worker/OffscreenAudioPlayer.js";
+import MessageType from "../../src/scripts/messaging/MessageType.js";
+
+const CLIP = "https://lexin.nada.kth.se/sound/v2/390998_2.mp3";
+const PAGE = "chrome-extension://lexin/html/offscreen.html";
+
+/**
+ * The Offscreen Document is where a pronunciation clip is allowed to load - the
+ * Translation Card's own document is the reader's page, whose CSP blocks it. What is
+ * worth pinning here is the document's lifetime, because the extension does not own
+ * it: Chrome closes an AUDIO_PLAYBACK document 30 seconds after the last sound, so
+ * "is there one?" is a question with a different answer on every click.
+ *
+ * See docs/adr/0004-offscreen-audio-playback.md.
+ */
+describe("OffscreenAudioPlayer", () => {
+
+    let player: OffscreenAudioPlayer;
+    let creates: number;
+    let sent: any[];
+    let documentExists: boolean;
+
+    /**
+     * A chrome double that behaves like the real one on the points that matter:
+     * getContexts reports the document only while it exists, createDocument rejects
+     * when one already does, and a message sent to a closed document goes unanswered.
+     *
+     * `answer` decides what an open document does with the clip - `undefined` stands
+     * for a document that takes the message and never responds. `closesAfterCheck`
+     * plays out the race the retry exists for: the document is there when getContexts
+     * is asked and gone by the time the message goes out.
+     */
+    function fakeChrome(options: {
+        exists?: boolean, answer?: (url: string) => any, closesAfterCheck?: boolean
+    } = {}) {
+        creates = 0;
+        sent = [];
+        documentExists = options.exists === true;
+        let closesAfterCheck = options.closesAfterCheck === true;
+        const answer = options.answer ?? (() => true);
+
+        (global as any).chrome = {
+            runtime: {
+                getURL: (path: string) => `chrome-extension://lexin/${path}`,
+                getContexts: (filter: any) => {
+                    const found = documentExists && filter.documentUrls[0] === PAGE;
+                    if (found && closesAfterCheck) {
+                        documentExists = false;
+                        closesAfterCheck = false;
+                    }
+                    return Promise.resolve(found ? [{ contextType: "OFFSCREEN_DOCUMENT" }] : []);
+                },
+                sendMessage: (message: any, callback: (response: any) => void) => {
+                    sent.push(message);
+                    callback(documentExists ? answer(message.args.url) : undefined);
+                }
+            },
+            offscreen: {
+                Reason: { AUDIO_PLAYBACK: "AUDIO_PLAYBACK" },
+                createDocument: () => {
+                    if (documentExists) {
+                        return Promise.reject(new Error("Only a single offscreen document may be created."));
+                    }
+                    creates++;
+                    documentExists = true;
+                    return Promise.resolve();
+                }
+            }
+        };
+    }
+
+    beforeEach(() => {
+        player = new OffscreenAudioPlayer();
+    });
+
+    afterEach(() => {
+        delete (global as any).chrome;
+    });
+
+    it("should open the document and send it the clip", async () => {
+        fakeChrome();
+
+        await player.play(CLIP);
+
+        expect(creates).toBe(1);
+        expect(sent).toEqual([{ method: MessageType.playAudioInOffscreenDocument, args: { url: CLIP } }]);
+    });
+
+    it("should reuse a document that is already open", async () => {
+        fakeChrome({ exists: true });
+
+        await player.play(CLIP);
+        await player.play(CLIP);
+
+        expect(creates).toBe(0);
+        expect(sent).toHaveLength(2);
+    });
+
+    it("should open one document for clips clicked at the same moment", async () => {
+        // Chrome allows a single Offscreen Document per extension and rejects the
+        // second createDocument, so two clicks must queue behind one creation.
+        fakeChrome();
+
+        await Promise.all([player.play(CLIP), player.play(CLIP)]);
+
+        expect(creates).toBe(1);
+        expect(sent).toHaveLength(2);
+    });
+
+    it("should reopen the document when it has been closed under it", async () => {
+        // Chrome closes the document after 30 seconds of silence. getContexts can
+        // therefore say "open" and the message still land nowhere - the retry is what
+        // keeps that from swallowing the click.
+        fakeChrome({ exists: true, closesAfterCheck: true });
+
+        await player.play(CLIP);
+
+        expect(creates).toBe(1);
+        expect(sent).toHaveLength(2);
+    });
+
+    it("should not retry forever when the document keeps silent", async () => {
+        const error = vi.spyOn(console, "error").mockImplementation(() => {});
+        fakeChrome({ answer: () => undefined });
+
+        try {
+            await player.play(CLIP);
+
+            expect(sent).toHaveLength(2);
+            expect(error).toHaveBeenCalled();
+        } finally {
+            error.mockRestore();
+        }
+    });
+
+    it("should survive a document it cannot open", async () => {
+        // The clip going silent is bad; an unhandled rejection in the service worker,
+        // which takes the message port down with it, is worse.
+        const error = vi.spyOn(console, "error").mockImplementation(() => {});
+        fakeChrome();
+        (global as any).chrome.offscreen.createDocument = () => Promise.reject(new Error("no document for you"));
+
+        try {
+            await expect(player.play(CLIP)).resolves.toBeUndefined();
+            expect(sent).toHaveLength(0);
+        } finally {
+            error.mockRestore();
+        }
+    });
+});

--- a/tests/unit/util/fakes.ts
+++ b/tests/unit/util/fakes.ts
@@ -15,8 +15,10 @@ import {
     OpenActionPopupHandler,
     LoadHistoryDirectionsHandler,
     RemoveHistoryItemHandler,
+    PlayAudioHandler,
     IAsyncStorage,
-    IAsyncSettingsStorage
+    IAsyncSettingsStorage,
+    IAudioPlayer
 } from "../../../src/scripts/common/Interfaces.js";
 import TranslationDirection from "../../../src/scripts/dictionary/TranslationDirection.js";
 
@@ -79,6 +81,23 @@ export class TestMessageService implements IMessageService {
     openActionPopup(): Promise<void> {
         this.openActionPopupCalls++;
         return Promise.resolve();
+    }
+
+    playedAudioUrls: string[] = [];
+
+    playAudio(url: string): Promise<void> {
+        this.playedAudioUrls.push(url);
+        return Promise.resolve();
+    }
+}
+
+export class FakeAudioPlayer implements IAudioPlayer {
+    playedUrls: string[] = [];
+    reject: any = null;
+
+    play(url: string): Promise<void> {
+        this.playedUrls.push(url);
+        return this.reject ? Promise.reject(this.reject) : Promise.resolve();
     }
 }
 
@@ -203,6 +222,8 @@ export class FakeMessageHandlers implements IMessageHandlers {
     openActionPopupHandler: OpenActionPopupHandler | null = null;
     loadHistoryDirectionsHandler: LoadHistoryDirectionsHandler | null = null;
     removeHistoryItemHandler: RemoveHistoryItemHandler | null = null;
+    playAudioHandler: PlayAudioHandler | null = null;
+    playAudioInOffscreenDocumentHandler: PlayAudioHandler | null = null;
 
     registerGetTranslationHandler(handler: GetTranslationHandler): void {
         this.getTranslationHandler = handler;
@@ -230,5 +251,13 @@ export class FakeMessageHandlers implements IMessageHandlers {
 
     registerRemoveHistoryItemHandler(handler: RemoveHistoryItemHandler): void {
         this.removeHistoryItemHandler = handler;
+    }
+
+    registerPlayAudioHandler(handler: PlayAudioHandler): void {
+        this.playAudioHandler = handler;
+    }
+
+    registerPlayAudioInOffscreenDocumentHandler(handler: PlayAudioHandler): void {
+        this.playAudioInOffscreenDocumentHandler = handler;
     }
 }


### PR DESCRIPTION
- Added support for playing pronunciation clips in an Offscreen Document to bypass Content Security Policy restrictions on host pages.
- Updated manifest to include the "offscreen" permission.
- Introduced new interfaces and message handlers for audio playback.
- Created OffscreenAudioPlayer to manage audio playback in the Offscreen Document.
- Implemented tests for audio playback functionality, ensuring proper handling of CSP violations and document lifecycle.
- Documented the rationale and implementation details in ADR 0004.