### PR TITLE
chore: implement versioning system for Chrome extension release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,34 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Cheap and first: a tag whose version disagrees with the committed
+  # src/manifest.json and package.json means the release was cut without
+  # `npm run release:version`, and every log line in the jobs below would name
+  # the wrong version. Fail here, in seconds, rather than after the E2E suite.
+  preflight:
+    name: Check the tag matches the committed version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Verify version
+        run: node scripts/webstore/verify-version.js "${GITHUB_REF_NAME}"
+
   verify:
     name: Lint, unit test, build
+    needs: preflight
     uses: ./.github/workflows/ci.yml
 
   e2e:
     name: E2E tests
+    needs: preflight
     uses: ./.github/workflows/test.yml
 
   publish:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,15 +13,58 @@ succeeds, and publishes a GitHub release for the tag.
 ## Cutting a release
 
 ```bash
-git tag v2.0.1
-git push origin v2.0.1
+npm run release -- 2.0.1
 ```
 
-The tag's version becomes the manifest version for that build only - it is
-written to `dist/manifest.json` during packaging and never touches
-`src/manifest.json`. Pick a version higher than both the version currently in
-`src/manifest.json` and whatever is already published to the store; the
-workflow's preflight check rejects non-incrementing versions.
+That is the whole thing. From a clean tree on the branch you are releasing,
+[`scripts/webstore/release.js`](scripts/webstore/release.js) writes the version
+into `src/manifest.json`, `package.json` and `package-lock.json`, commits it as
+`chore: release 2.0.1`, pushes the branch, tags `v2.0.1` and pushes the tag -
+which is what starts everything in `release.yml`. It prints the plan and asks
+before pushing, since the push is the point of no return.
+
+| | |
+|---|---|
+| `--dry-run` | run the checks, print the plan, change nothing |
+| `--no-push` | bump, commit and tag locally; print the pushes to run |
+| `--yes`, `-y` | skip the confirmation (required when stdin is not a terminal) |
+| `--remote=<name>` | push somewhere other than `origin` |
+
+Pick a version higher than both the version currently in `src/manifest.json`
+and whatever is already published to the store; the workflow's Chrome Web Store
+preflight rejects non-incrementing versions.
+
+Before touching anything it refuses to go on if the working tree is dirty (the
+release commit would sweep the changes in), if `HEAD` is detached, if the
+version is older than the committed one, or if the tag already exists locally
+or on the remote. The branch is pushed *before* the tag is created, so a
+rejected push - someone else got there first - leaves no tag to clean up: pull,
+and run the same command again. Re-running after a `--no-push` or a failed push
+is expected to work; it notices the version files are already right, skips the
+commit, and goes on to the tag.
+
+`npm run release:version -- 2.0.1`
+([`scripts/webstore/bump.js`](scripts/webstore/bump.js)) writes those three
+files and stops, for when you want to commit and tag by hand.
+
+The bump lands before the tag either way, so the tag names a commit that
+already agrees with what is being released. The workflow's first job
+([`scripts/webstore/verify-version.js`](scripts/webstore/verify-version.js))
+compares the tag against those committed files and fails the release in seconds
+if they disagree. A unit test checks the same three files against each other on
+every pull request, so a hand-edit of one of them surfaces long before a
+release.
+
+Keeping `package.json` in step is not cosmetic: npm prints it at the head of
+every script it runs, so a stale one has every build and test log announcing a
+version the extension left behind releases ago.
+
+Chrome allows a fourth version component and npm does not, so a `vX.Y.Z.W` tag
+puts `X.Y.Z.W` in the manifest and `X.Y.Z` in the npm files.
+
+Packaging still stamps the tag's version into `dist/manifest.json` itself and
+never reads the committed one, so the ZIP matches its tag no matter what.
+`src/manifest.json` is never touched by the workflow.
 
 The GitHub release page appears as soon as the store accepts the submission,
 which is earlier than the extension going live - Google publishes it
@@ -120,41 +163,45 @@ first release doubles as the test of the OIDC path.
 
 ## What the workflow does
 
-1. Calls `ci.yml` (lint, unit tests, build) and `test.yml` (Docker-based
+1. Checks the tag against the versions committed to the repo
+   (`scripts/webstore/verify-version.js`). It runs on its own, before
+   everything else, so a tag pushed without `npm run release:version` costs
+   seconds rather than a full E2E run.
+2. Calls `ci.yml` (lint, unit tests, build) and `test.yml` (Docker-based
    Playwright E2E suite) as reusable workflow jobs - the exact same gates as
    ordinary CI, defined once and shared rather than duplicated. Only once both
    succeed does the `publish` job rebuild `dist/` (needed locally to package
    it) and continue.
-2. Packages `dist/` into `lexin-extension-<version>.zip` with `manifest.json`
+3. Packages `dist/` into `lexin-extension-<version>.zip` with `manifest.json`
    at the root (`scripts/webstore/package.js`), plus a `.sha256` checksum.
    Two builds from the same commit and tag produce byte-identical ZIPs.
-3. Inspects the ZIP (`scripts/webstore/inspect-zip.js`) to confirm the
+4. Inspects the ZIP (`scripts/webstore/inspect-zip.js`) to confirm the
    expected top-level files are present and the manifest version matches the
    tag.
-4. Uploads the ZIP and checksum as a workflow artifact for audit/debugging.
-5. Authenticates to Google Cloud via `google-github-actions/auth`, requesting
+5. Uploads the ZIP and checksum as a workflow artifact for audit/debugging.
+6. Authenticates to Google Cloud via `google-github-actions/auth`, requesting
    a short-lived `chromewebstore`-scoped access token (`token_format:
    access_token`, `create_credentials_file: false`) - no JSON key ever touches
    the runner.
-6. Runs a preflight (`scripts/webstore/chrome-web-store.js`'s `fetchStatus` /
-   `assertReleasable`) that blocks the release if the item has been taken
-   down, is under an active policy warning, already has a submission awaiting
-   review, or the target version does not increment the published version.
-7. Uploads the package via the v2 `media.upload` endpoint, polling with a
+7. Runs a Chrome Web Store preflight (`scripts/webstore/chrome-web-store.js`'s
+   `fetchStatus` / `assertReleasable`) that blocks the release if the item has
+   been taken down, is under an active policy warning, already has a submission
+   awaiting review, or the target version does not increment the published one.
+8. Uploads the package via the v2 `media.upload` endpoint, polling with a
    bounded number of attempts if the API reports `UPLOAD_IN_PROGRESS`.
-8. Submits the item for publication via the v2 `publish` endpoint
+9. Submits the item for publication via the v2 `publish` endpoint
    (`publishType: DEFAULT_PUBLISH`, `blockOnWarnings: true`). Google publishes
    it automatically once review succeeds - the workflow's job succeeding means
    "accepted and submitted for review", not "live in the store".
-9. Writes a job summary with the version, checksum, extension ID, and
-   returned submission state. Credentials are never printed.
-10. In a separate `github-release` job, downloads that artifact and creates the
+10. Writes a job summary with the version, checksum, extension ID, and
+    returned submission state. Credentials are never printed.
+11. In a separate `github-release` job, downloads that artifact and creates the
     GitHub release for the tag with auto-generated notes and the ZIP and its
     checksum attached, so the exact submitted package outlives the 90-day
     artifact retention.
 
     It is a distinct job on purpose. The store submission is not repeatable -
-    the preflight in step 6 blocks a second upload while the first still awaits
+    the preflight in step 7 blocks a second upload while the first still awaits
     review - so if release creation were a step on the publish job, a transient
     GitHub API failure would be unrecoverable: GitHub re-runs whole jobs, and
     the retry would fail at the store step before ever reaching it. Split out,

--- a/agents.md
+++ b/agents.md
@@ -598,6 +598,15 @@ Animation utilities:
 Releases are packaged and published to the Chrome Web Store by CI on a `vX.Y.Z`
 tag push (`scripts/webstore/package.js`); see [RELEASE.md](RELEASE.md).
 
+`npm run release -- <version>` cuts one end to end: it bumps the version,
+commits, tags and pushes.
+
+The version lives in `src/manifest.json`, `package.json` and
+`package-lock.json`, and that command (or `npm run release:version` for the
+files alone) is the only thing that should write it - never edit one of the
+three by hand. A unit test holds them to each other, and the release workflow
+refuses a tag that disagrees with them.
+
 ---
 
 ## Analytics & Tracking

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lexin-chrome-extension",
-  "version": "1.8.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexin-chrome-extension",
-      "version": "1.8.0",
+      "version": "3.0.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@playwright/test": "1.62.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lexin-chrome-extension",
-  "version": "1.8.0",
+  "version": "3.0.0",
   "description": "Swedish to other languages dictionary. Powered by Lexin and Folkets Lexikon",
   "scripts": {
     "clean": "rm -rf dist",
@@ -22,7 +22,9 @@
     "test:e2e:ui": "npm run build && npx playwright test --ui",
     "test:e2e:docker": "./scripts/run-tests-docker.sh",
     "store-assets": "npm run build && node scripts/store-assets/capture.mjs",
-    "dev": "node scripts/dev.js"
+    "dev": "node scripts/dev.js",
+    "release": "node scripts/webstore/release.js",
+    "release:version": "node scripts/webstore/bump.js"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/scripts/webstore/bump.js
+++ b/scripts/webstore/bump.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Stamps a release version into the files that are committed to the repo:
+// src/manifest.json, package.json and package-lock.json.
+//
+// Usage: npm run release:version -- <version|tag>   (3.1.0 or v3.1.0)
+//
+// This writes the files and stops there. `npm run release` (release.js) is the
+// one to reach for when actually cutting a release - it calls this, then
+// commits, tags and pushes.
+//
+// Either way the version lands before the tag, so the tag names a commit whose
+// manifest already carries the version being released. The release workflow's
+// preflight (verify-version.js) enforces that, which is what keeps the two from
+// drifting apart the way they did up to 3.0.0 - src/manifest.json was bumped by hand and
+// package.json sat at 1.8.0 for four releases, so every build and test log
+// announced a version the extension had long left behind.
+//
+// This is the only place src/manifest.json's version is written. Packaging
+// (package.js) still stamps the tag version into dist/manifest.json rather than
+// trusting the committed one, so a release ZIP always matches its tag even if
+// something here was skipped.
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseTagVersion, toPackageVersion, validateChromeVersion } from "./version.js";
+
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+export const MANIFEST_FILE = path.join("src", "manifest.json");
+export const PACKAGE_FILE = "package.json";
+export const LOCK_FILE = "package-lock.json";
+
+/**
+ * Accepts either a bare version ("3.1.0") or a release tag ("v3.1.0") and
+ * returns the validated version.
+ *
+ * A bare version is routed through parseTagVersion as well, so it is held to
+ * the same X.Y.Z(.W) shape the tag will need. Chrome would accept "3.1", but
+ * the tag it becomes - `v3.1` - does not match release.yml's `v*.*.*` trigger:
+ * pushing it would silently run nothing at all. Better to fail here.
+ */
+export function resolveVersionInput(input) {
+  if (typeof input !== "string") {
+    throw new Error(`Version must be a string, got ${typeof input}`);
+  }
+
+  const trimmed = input.trim();
+  const tag = trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
+  return validateChromeVersion(parseTagVersion(tag));
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, "utf-8"));
+}
+
+// npm writes both JSON files with two-space indentation and a trailing newline,
+// so rewriting them this way leaves no formatting diff for `npm install` to undo.
+async function writeJson(filePath, data) {
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Reads the versions currently committed to the repo.
+ */
+export async function readVersions(root = REPO_ROOT) {
+  const [manifest, pkg, lock] = await Promise.all([
+    readJson(path.join(root, MANIFEST_FILE)),
+    readJson(path.join(root, PACKAGE_FILE)),
+    readJson(path.join(root, LOCK_FILE))
+  ]);
+
+  return {
+    manifest: manifest.version,
+    package: pkg.version,
+    // lockfileVersion 2+ repeats the root package's version under packages[""].
+    // npm rewrites it from package.json on the next install, so leaving it stale
+    // would surface as an unrelated diff in someone else's PR.
+    lock: lock.version,
+    lockPackage: lock.packages?.[""]?.version
+  };
+}
+
+/**
+ * Writes `version` into the manifest and the npm files, and returns what each
+ * held before.
+ */
+export async function applyVersion(version, root = REPO_ROOT) {
+  const manifestVersion = validateChromeVersion(version);
+  const packageVersion = toPackageVersion(manifestVersion);
+  const previous = await readVersions(root);
+
+  const manifestPath = path.join(root, MANIFEST_FILE);
+  const manifest = await readJson(manifestPath);
+  manifest.version = manifestVersion;
+  await writeJson(manifestPath, manifest);
+
+  const packagePath = path.join(root, PACKAGE_FILE);
+  const pkg = await readJson(packagePath);
+  pkg.version = packageVersion;
+  await writeJson(packagePath, pkg);
+
+  const lockPath = path.join(root, LOCK_FILE);
+  const lock = await readJson(lockPath);
+  lock.version = packageVersion;
+  if (lock.packages?.[""]) {
+    lock.packages[""].version = packageVersion;
+  }
+  await writeJson(lockPath, lock);
+
+  return { manifestVersion, packageVersion, previous };
+}
+
+async function main() {
+  const input = process.env.RELEASE_VERSION || process.argv[2];
+  if (!input) {
+    throw new Error("Usage: npm run release:version -- <version>   (e.g. 3.1.0)");
+  }
+
+  const version = resolveVersionInput(input);
+  const { manifestVersion, packageVersion, previous } = await applyVersion(version);
+
+  console.log(`${MANIFEST_FILE}: ${previous.manifest} -> ${manifestVersion}`);
+  console.log(`${PACKAGE_FILE}: ${previous.package} -> ${packageVersion}`);
+  console.log(`${LOCK_FILE}: ${previous.lock} -> ${packageVersion}`);
+  console.log("");
+  console.log("Files only - commit and tag yourself, or let `npm run release` do all of it.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/webstore/release.js
+++ b/scripts/webstore/release.js
@@ -51,7 +51,21 @@ export function parseArgs(argv) {
 }
 
 function run(args) {
-  return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf-8" }).trim();
+  try {
+    // stdio pipes git's stderr rather than letting it through to this script's,
+    // so the one probe whose failure is tolerated - hasRemoteTag on an
+    // unreachable remote - does not print a "fatal:" that reads like a crash.
+    // Everything else re-throws with git's own message attached, so a failing
+    // push still says why.
+    return execFileSync("git", args, {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"]
+    }).trim();
+  } catch (error) {
+    const details = String(error.stderr ?? "").trim();
+    throw new Error(details ? `git ${args[0]} failed - ${details}` : `git ${args[0]} failed`);
+  }
 }
 
 /** The git surface this script needs, narrow enough for a test to stand in for. */
@@ -88,7 +102,9 @@ export function assertReadyToRelease({ version, tag, state, remote }) {
     throw new Error("HEAD is detached. Check out the branch you are releasing from.");
   }
 
-  if (compareChromeVersions(version, state.current) < 0) {
+  const comparison = compareChromeVersions(version, state.current);
+
+  if (comparison < 0) {
     throw new Error(
       `Version ${version} is older than the committed version ${state.current}. ` +
       "The Chrome Web Store rejects a submission that does not increment the published one."
@@ -99,6 +115,18 @@ export function assertReadyToRelease({ version, tag, state, remote }) {
   // after a --no-push or a rejected push, where the bump commit landed and only
   // the tag is missing. Re-releasing a version that genuinely shipped is caught
   // by the tag checks below instead - the last release left its tag behind.
+  //
+  // Only a textually identical version, though. "3.0.0.0" against a committed
+  // "3.0.0" compares equal but makes a different tag name, so it slips past
+  // both tag checks - and the store, which compares the way Chrome does, then
+  // rejects the submission as non-incrementing after a full CI and E2E run.
+  if (comparison === 0 && version !== state.current) {
+    throw new Error(
+      `Version ${version} is the committed version ${state.current} written differently - ` +
+      "Chrome and the store read them as the same version. Pick a version that increments it."
+    );
+  }
+
   if (state.hasTag) {
     throw new Error(`Tag ${tag} already exists locally. Delete it (git tag -d ${tag}) or pick another version.`);
   }
@@ -138,15 +166,32 @@ export async function runRelease(input, options = {}, deps = {}) {
   const remote = options.remote ?? DEFAULT_REMOTE;
 
   const branch = git.currentBranch();
+  // Asked even for --no-push: a tag already on the remote makes the release
+  // commit a mistake, and a stale clone will not have that tag locally for the
+  // check above to catch. An unreachable remote is not fatal, though -
+  // preparing a release offline is a fair thing to want - so it degrades to a
+  // warning, and a push that needs the network fails loudly moments later.
+  let hasRemoteTag = false;
+  let remoteReachable = true;
+  try {
+    hasRemoteTag = git.hasRemoteTag(remote, tag);
+  } catch {
+    remoteReachable = false;
+  }
+
   const state = {
     dirty: git.isDirty(),
     branch,
     current: (await readCurrentVersions()).manifest,
     hasTag: git.hasTag(tag),
-    hasRemoteTag: options.push ? git.hasRemoteTag(remote, tag) : false
+    hasRemoteTag
   };
 
   assertReadyToRelease({ version, tag, state, remote });
+
+  if (!remoteReachable) {
+    log(`Note: could not reach ${remote}, so whether ${tag} already exists there is unknown.`);
+  }
 
   const message = `chore: release ${version}`;
   log(`Releasing ${state.current} -> ${version}`);

--- a/scripts/webstore/release.js
+++ b/scripts/webstore/release.js
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+// Cuts a release: bumps the version files, commits, pushes, tags, pushes the
+// tag - which is what starts the Chrome Web Store submission over in
+// release.yml.
+//
+// Usage: npm run release -- <version> [options]      (3.1.0 or v3.1.0)
+//
+//   --no-push        bump, commit and tag locally; print the pushes to run
+//   --dry-run        run the checks and print the plan, change nothing
+//   --yes, -y        skip the confirmation prompt (required when not a TTY)
+//   --remote=<name>  push somewhere other than origin
+//
+// The branch is pushed before the tag is created, so a rejected push (someone
+// else got there first) leaves no tag behind to clean up - re-pull and re-run.
+import { execFileSync } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import { applyVersion, readVersions, resolveVersionInput, REPO_ROOT } from "./bump.js";
+import { compareChromeVersions } from "./version.js";
+
+export const DEFAULT_REMOTE = "origin";
+// Releases are cut from master. Anywhere else is allowed - a tag can point at
+// any commit - but it is worth saying out loud before the push.
+export const RELEASE_BRANCH = "master";
+
+export function parseArgs(argv) {
+  const options = { push: true, yes: false, dryRun: false, remote: DEFAULT_REMOTE };
+  const positional = [];
+
+  for (const arg of argv) {
+    if (arg === "--no-push") {
+      options.push = false;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--yes" || arg === "-y") {
+      options.yes = true;
+    } else if (arg.startsWith("--remote=")) {
+      options.remote = arg.slice("--remote=".length);
+    } else if (arg.startsWith("-")) {
+      throw new Error(`Unknown option "${arg}"`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (positional.length > 1) {
+    throw new Error(`Expected one version, got ${positional.length}: ${positional.join(", ")}`);
+  }
+
+  options.version = positional[0];
+  return options;
+}
+
+function run(args) {
+  return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf-8" }).trim();
+}
+
+/** The git surface this script needs, narrow enough for a test to stand in for. */
+export function createGit(exec = run) {
+  return {
+    isDirty: () => exec(["status", "--porcelain"]) !== "",
+    currentBranch: () => exec(["rev-parse", "--abbrev-ref", "HEAD"]),
+    // `tag --list` prints nothing and exits 0 for an unknown tag, where
+    // `rev-parse` would exit non-zero and throw.
+    hasTag: (tag) => exec(["tag", "--list", tag]) !== "",
+    hasRemoteTag: (remote, tag) => exec(["ls-remote", "--tags", remote, `refs/tags/${tag}`]) !== "",
+    remoteUrl: (remote) => exec(["remote", "get-url", remote]),
+    commitAll: (message) => exec(["commit", "--quiet", "--all", "--message", message]),
+    createTag: (tag, message) => exec(["tag", "--annotate", tag, "--message", message]),
+    // --quiet drops git's progress report, which only repeats what this script
+    // logs; a failing push still writes its error to stderr.
+    push: (remote, ref) => exec(["push", "--quiet", remote, ref])
+  };
+}
+
+/**
+ * Refuses a release the repo is not in a state to cut. Every check here is one
+ * that is cheaper to fail locally than after a tag has been pushed.
+ */
+export function assertReadyToRelease({ version, tag, state, remote }) {
+  if (state.dirty) {
+    throw new Error(
+      "The working tree has uncommitted changes. The release commit takes everything " +
+      "tracked, so commit or stash them first."
+    );
+  }
+
+  if (state.branch === "HEAD") {
+    throw new Error("HEAD is detached. Check out the branch you are releasing from.");
+  }
+
+  if (compareChromeVersions(version, state.current) < 0) {
+    throw new Error(
+      `Version ${version} is older than the committed version ${state.current}. ` +
+      "The Chrome Web Store rejects a submission that does not increment the published one."
+    );
+  }
+
+  // Equal to the committed version is deliberately allowed: that is a re-run
+  // after a --no-push or a rejected push, where the bump commit landed and only
+  // the tag is missing. Re-releasing a version that genuinely shipped is caught
+  // by the tag checks below instead - the last release left its tag behind.
+  if (state.hasTag) {
+    throw new Error(`Tag ${tag} already exists locally. Delete it (git tag -d ${tag}) or pick another version.`);
+  }
+
+  if (state.hasRemoteTag) {
+    throw new Error(`Tag ${tag} already exists on ${remote}, so ${version} has been released already.`);
+  }
+}
+
+/** The GitHub Actions page for a remote, so the run can be watched. */
+export function actionsUrl(remoteUrl) {
+  const match = /github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/.exec(remoteUrl ?? "");
+  return match ? `https://github.com/${match[1]}/actions` : null;
+}
+
+async function confirmOnTty(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(`${question} [y/N] `);
+    return answer.trim().toLowerCase() === "y";
+  } finally {
+    rl.close();
+  }
+}
+
+export async function runRelease(input, options = {}, deps = {}) {
+  const {
+    git = createGit(),
+    readCurrentVersions = readVersions,
+    writeVersion = applyVersion,
+    confirm = confirmOnTty,
+    log = console.log
+  } = deps;
+
+  const version = resolveVersionInput(input);
+  const tag = `v${version}`;
+  const remote = options.remote ?? DEFAULT_REMOTE;
+
+  const branch = git.currentBranch();
+  const state = {
+    dirty: git.isDirty(),
+    branch,
+    current: (await readCurrentVersions()).manifest,
+    hasTag: git.hasTag(tag),
+    hasRemoteTag: options.push ? git.hasRemoteTag(remote, tag) : false
+  };
+
+  assertReadyToRelease({ version, tag, state, remote });
+
+  const message = `chore: release ${version}`;
+  log(`Releasing ${state.current} -> ${version}`);
+  log(`  commit  ${message}`);
+  log(`  tag     ${tag}`);
+  log(options.push ? `  push    ${branch} and ${tag} to ${remote}` : "  push    skipped (--no-push)");
+
+  if (branch !== RELEASE_BRANCH) {
+    log(`\nNote: releasing from "${branch}", not ${RELEASE_BRANCH}.`);
+  }
+
+  if (options.dryRun) {
+    log("\nDry run - nothing changed.");
+    return { version, tag, branch, remote, pushed: false, dryRun: true };
+  }
+
+  if (options.push && !options.yes) {
+    log("\nPushing the tag submits the extension to the Chrome Web Store.");
+    if (!await confirm("Continue?")) {
+      log("Aborted - nothing changed.");
+      return { version, tag, branch, remote, pushed: false, aborted: true };
+    }
+  }
+
+  await writeVersion(version);
+
+  // Nothing to commit means the files already carried this version - a re-run
+  // after a push failed, most likely. Carry on to the tag rather than dying on
+  // git's "nothing to commit".
+  if (git.isDirty()) {
+    git.commitAll(message);
+    log(`\nCommitted ${message}`);
+  } else {
+    log("\nVersion files already at this version - nothing to commit.");
+  }
+
+  if (!options.push) {
+    git.createTag(tag, message);
+    log(`Tagged ${tag}`);
+    log("\nPush when ready:");
+    log(`  git push ${remote} ${branch} && git push ${remote} ${tag}`);
+    return { version, tag, branch, remote, pushed: false };
+  }
+
+  // Branch first, tag second: if the branch push is rejected there is no tag to
+  // undo, and a tag is the one thing here that cannot be quietly re-cut.
+  git.push(remote, branch);
+  log(`Pushed ${branch} to ${remote}`);
+
+  git.createTag(tag, message);
+  git.push(remote, tag);
+  log(`Pushed ${tag} to ${remote} - the release workflow is running.`);
+
+  const url = actionsUrl(git.remoteUrl(remote));
+  if (url) {
+    log(url);
+  }
+
+  return { version, tag, branch, remote, pushed: true };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (!options.version) {
+    throw new Error("Usage: npm run release -- <version> [--no-push] [--dry-run] [--yes]");
+  }
+
+  if (options.push && !options.yes && !options.dryRun && !process.stdin.isTTY) {
+    throw new Error("Not a terminal, so the confirmation cannot be asked for. Re-run with --yes.");
+  }
+
+  await runRelease(options.version, options);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/webstore/verify-version.js
+++ b/scripts/webstore/verify-version.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Checks that the versions committed to the repo match the tag being released.
+//
+// Usage: node scripts/webstore/verify-version.js <tag>
+//
+// The release workflow runs this before anything is built, so a tag pushed
+// without running `npm run release:version` first fails in seconds rather than
+// shipping a store submission whose repo says otherwise. The check is on the
+// committed files only - packaging stamps dist/manifest.json from the tag
+// regardless, so this is about the repo telling the truth, not about the ZIP.
+import { readVersions, MANIFEST_FILE, PACKAGE_FILE, LOCK_FILE } from "./bump.js";
+import { parseTagVersion, toPackageVersion } from "./version.js";
+
+/**
+ * Returns the mismatches between a tag's version and the committed versions,
+ * as one human-readable line each. An empty array means everything agrees.
+ */
+export function findVersionMismatches(tag, versions) {
+  const manifestVersion = parseTagVersion(tag);
+  const packageVersion = toPackageVersion(manifestVersion);
+  const mismatches = [];
+
+  if (versions.manifest !== manifestVersion) {
+    mismatches.push(`${MANIFEST_FILE} says "${versions.manifest}", tag ${tag} means "${manifestVersion}"`);
+  }
+
+  if (versions.package !== packageVersion) {
+    mismatches.push(`${PACKAGE_FILE} says "${versions.package}", tag ${tag} means "${packageVersion}"`);
+  }
+
+  if (versions.lock !== packageVersion || versions.lockPackage !== packageVersion) {
+    mismatches.push(
+      `${LOCK_FILE} says "${versions.lock}"/"${versions.lockPackage}", tag ${tag} means "${packageVersion}"`
+    );
+  }
+
+  return mismatches;
+}
+
+async function main() {
+  const tag = process.env.RELEASE_TAG || process.argv[2];
+  if (!tag) {
+    throw new Error("Usage: node scripts/webstore/verify-version.js <tag>");
+  }
+
+  const versions = await readVersions();
+  const mismatches = findVersionMismatches(tag, versions);
+
+  if (mismatches.length > 0) {
+    const version = parseTagVersion(tag);
+    throw new Error(
+      [
+        "The committed versions do not match the tag being released:",
+        ...mismatches.map((line) => `  - ${line}`),
+        "",
+        `Fix it on the release branch with \`npm run release:version -- ${version}\`,`,
+        `commit, then re-tag ${tag} at that commit.`
+      ].join("\n")
+    );
+  }
+
+  console.log(`Version check OK: ${tag} matches ${MANIFEST_FILE}, ${PACKAGE_FILE} and ${LOCK_FILE}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/webstore/version.js
+++ b/scripts/webstore/version.js
@@ -3,6 +3,8 @@
 // and the components must not all be zero.
 export const CHROME_VERSION_MAX_COMPONENTS = 4;
 export const CHROME_VERSION_COMPONENT_MAX = 65535;
+// npm's package.json version is semver: exactly major.minor.patch.
+export const PACKAGE_VERSION_COMPONENTS = 3;
 
 /**
  * Extracts the raw version string from a release tag.
@@ -70,6 +72,27 @@ export function validateChromeVersion(version) {
  */
 export function resolveReleaseVersion(tag) {
   return validateChromeVersion(parseTagVersion(tag));
+}
+
+/**
+ * Converts a Chrome manifest version into the three-component form npm requires
+ * in package.json.
+ *
+ * Chrome allows 1 to 4 components; semver allows exactly 3. Missing components
+ * are padded with zeros, and a fourth - Chrome's rebuild counter, which npm has
+ * no equivalent of - is dropped: "3.1" becomes "3.1.0", "3.1.0.2" becomes
+ * "3.1.0". Two releases that differ only in that fourth component therefore
+ * share a package.json version, which is fine - nothing here is published to
+ * npm, the field exists to label build and test output.
+ */
+export function toPackageVersion(version) {
+  const parts = validateChromeVersion(version).split(".");
+
+  while (parts.length < PACKAGE_VERSION_COMPONENTS) {
+    parts.push("0");
+  }
+
+  return parts.slice(0, PACKAGE_VERSION_COMPONENTS).join(".");
 }
 
 /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Lexin dictionary",
-  "version": "3.0.0.0",
+  "version": "3.0.0",
   "minimum_chrome_version": "116",
   "description": "Swedish to other languages dictionary. Powered by Lexin and Folkets Lexikon",
   "icons": {

--- a/tests/unit/ReleaseScriptTests.ts
+++ b/tests/unit/ReleaseScriptTests.ts
@@ -116,6 +116,14 @@ describe("assertReadyToRelease", () => {
         expect(() => assertReadyToRelease(resume)).not.toThrow();
     });
 
+    it("refuses a version that is the committed one spelled differently", () => {
+        // 3.0.0.0 compares equal to 3.0.0 but makes tag v3.0.0.0, which neither
+        // tag check knows about. The store reads them as one version and would
+        // reject the submission - after a full CI and E2E run.
+        expect(() => assertReadyToRelease({ ...ready, version: "3.0.0.0", tag: "v3.0.0.0" }))
+            .toThrow(/written differently/);
+    });
+
     it("still refuses that re-cut once the tag is on the remote", () => {
         const released = {
             ...ready,
@@ -209,6 +217,33 @@ describe("runRelease", () => {
         await runRelease("3.1.0", { push: true, yes: true }, deps);
 
         expect(deps.git.calls).toEqual(["push origin master", "tag v3.1.0", "push origin v3.1.0"]);
+    });
+
+    it("asks the remote about the tag even with --no-push", async () => {
+        // A stale clone has no local v3.1.0 to catch, so without this the run
+        // builds a release commit around a tag that is already taken.
+        const asked: string[] = [];
+        const git = fakeGit({
+            hasRemoteTag: (remote: string, tag: string) => { asked.push(`${remote} ${tag}`); return true; }
+        });
+
+        await expect(runRelease("3.1.0", { push: false, yes: true }, fakeDeps(git)))
+            .rejects.toThrow(/released already/);
+        expect(asked).toEqual(["origin v3.1.0"]);
+        expect(git.calls).toEqual([]);
+    });
+
+    it("carries on with a note when the remote cannot be reached", async () => {
+        const logged: string[] = [];
+        const git = fakeGit({
+            hasRemoteTag: () => { throw new Error("could not read from remote repository"); }
+        });
+        const deps = { ...fakeDeps(git), log: (line: string) => logged.push(line) };
+
+        const result = await runRelease("3.1.0", { push: false, yes: true }, deps);
+
+        expect(result.version).toBe("3.1.0");
+        expect(logged.some((line) => line.includes("could not reach origin"))).toBe(true);
     });
 
     it("honours --remote", async () => {

--- a/tests/unit/ReleaseScriptTests.ts
+++ b/tests/unit/ReleaseScriptTests.ts
@@ -1,0 +1,290 @@
+import {
+    parseArgs,
+    assertReadyToRelease,
+    actionsUrl,
+    createGit,
+    runRelease,
+    DEFAULT_REMOTE
+} from "../../scripts/webstore/release.js";
+
+/**
+ * `npm run release` is the one command that can put a tag on the remote, and a
+ * pushed tag submits the extension to the Chrome Web Store - there is no
+ * un-pushing that. So the checks in front of it, and the order it does things
+ * in, are what these tests are about.
+ */
+
+/** Records what the release script asked git to do, in order. */
+function fakeGit(overrides: Record<string, unknown> = {}) {
+    const calls: string[] = [];
+    let dirty = false;
+
+    const git = {
+        calls,
+        setDirty: (value: boolean) => { dirty = value; },
+        isDirty: () => dirty,
+        currentBranch: () => "master",
+        hasTag: () => false,
+        hasRemoteTag: () => false,
+        remoteUrl: () => "git@github.com:SergVro/Lexin-dictionary-Chrome-Extension.git",
+        commitAll: (message: string) => { calls.push(`commit ${message}`); dirty = false; },
+        createTag: (tag: string) => { calls.push(`tag ${tag}`); },
+        push: (remote: string, ref: string) => { calls.push(`push ${remote} ${ref}`); },
+        ...overrides
+    };
+
+    return git;
+}
+
+function fakeDeps(git = fakeGit(), current = "3.0.0") {
+    const written: string[] = [];
+
+    return {
+        git,
+        written,
+        readCurrentVersions: async () => ({ manifest: current, package: current, lock: current, lockPackage: current }),
+        writeVersion: async (version: string) => {
+            written.push(version);
+            git.setDirty(true);
+        },
+        confirm: async () => true,
+        log: () => { }
+    };
+}
+
+describe("parseArgs", () => {
+
+    it("takes the version as the only positional argument", () => {
+        expect(parseArgs(["3.1.0"])).toMatchObject({ version: "3.1.0", push: true, dryRun: false, yes: false });
+    });
+
+    it("defaults to pushing to origin", () => {
+        expect(parseArgs(["3.1.0"]).remote).toBe(DEFAULT_REMOTE);
+    });
+
+    it("reads the flags", () => {
+        const options = parseArgs(["v3.1.0", "--no-push", "--dry-run", "-y", "--remote=upstream"]);
+        expect(options).toMatchObject({
+            version: "v3.1.0",
+            push: false,
+            dryRun: true,
+            yes: true,
+            remote: "upstream"
+        });
+    });
+
+    it("rejects an unknown flag rather than treating it as a version", () => {
+        expect(() => parseArgs(["3.1.0", "--publish"])).toThrow(/Unknown option/);
+    });
+
+    it("rejects a second version", () => {
+        expect(() => parseArgs(["3.1.0", "3.2.0"])).toThrow(/Expected one version/);
+    });
+});
+
+describe("assertReadyToRelease", () => {
+
+    const ready = {
+        version: "3.1.0",
+        tag: "v3.1.0",
+        remote: "origin",
+        state: { dirty: false, branch: "master", current: "3.0.0", hasTag: false, hasRemoteTag: false }
+    };
+
+    it("passes on a clean tree with an incrementing version", () => {
+        expect(() => assertReadyToRelease(ready)).not.toThrow();
+    });
+
+    it("refuses to sweep uncommitted changes into the release commit", () => {
+        expect(() => assertReadyToRelease({ ...ready, state: { ...ready.state, dirty: true } }))
+            .toThrow(/uncommitted changes/);
+    });
+
+    it("refuses a detached HEAD, which has no branch to push", () => {
+        expect(() => assertReadyToRelease({ ...ready, state: { ...ready.state, branch: "HEAD" } }))
+            .toThrow(/detached/);
+    });
+
+    it("refuses a version older than the one committed", () => {
+        expect(() => assertReadyToRelease({ ...ready, version: "2.9.0" })).toThrow(/older than/);
+    });
+
+    it("allows re-cutting the committed version when no tag exists for it", () => {
+        // The resume case: the bump commit landed, the push did not. Refusing
+        // here would leave the repo bumped with no way to finish the release.
+        const resume = { ...ready, version: "3.0.0", tag: "v3.0.0" };
+        expect(() => assertReadyToRelease(resume)).not.toThrow();
+    });
+
+    it("still refuses that re-cut once the tag is on the remote", () => {
+        const released = {
+            ...ready,
+            version: "3.0.0",
+            tag: "v3.0.0",
+            state: { ...ready.state, hasRemoteTag: true }
+        };
+        expect(() => assertReadyToRelease(released)).toThrow(/released already/);
+    });
+
+    it("refuses a tag that already exists locally", () => {
+        expect(() => assertReadyToRelease({ ...ready, state: { ...ready.state, hasTag: true } }))
+            .toThrow(/already exists locally/);
+    });
+
+    it("refuses a version already released from the remote's point of view", () => {
+        expect(() => assertReadyToRelease({ ...ready, state: { ...ready.state, hasRemoteTag: true } }))
+            .toThrow(/released already/);
+    });
+});
+
+describe("runRelease", () => {
+
+    it("pushes the branch before creating the tag", async () => {
+        const deps = fakeDeps();
+
+        await runRelease("3.1.0", { push: true, yes: true }, deps);
+
+        // A rejected branch push must not leave a tag behind: the tag is the one
+        // step that cannot be quietly re-cut.
+        expect(deps.git.calls).toEqual([
+            "commit chore: release 3.1.0",
+            "push origin master",
+            "tag v3.1.0",
+            "push origin v3.1.0"
+        ]);
+    });
+
+    it("writes the version files before committing", async () => {
+        const deps = fakeDeps();
+
+        const result = await runRelease("v3.1.0", { push: true, yes: true }, deps);
+
+        expect(deps.written).toEqual(["3.1.0"]);
+        expect(result).toMatchObject({ version: "3.1.0", tag: "v3.1.0", pushed: true });
+    });
+
+    it("stops after tagging with --no-push", async () => {
+        const deps = fakeDeps();
+
+        const result = await runRelease("3.1.0", { push: false, yes: true }, deps);
+
+        expect(deps.git.calls).toEqual(["commit chore: release 3.1.0", "tag v3.1.0"]);
+        expect(result.pushed).toBe(false);
+    });
+
+    it("changes nothing on a dry run", async () => {
+        const deps = fakeDeps();
+
+        const result = await runRelease("3.1.0", { push: true, dryRun: true }, deps);
+
+        expect(deps.written).toEqual([]);
+        expect(deps.git.calls).toEqual([]);
+        expect(result).toMatchObject({ dryRun: true, pushed: false });
+    });
+
+    it("changes nothing when the confirmation is declined", async () => {
+        const deps = { ...fakeDeps(), confirm: async () => false };
+
+        const result = await runRelease("3.1.0", { push: true }, deps);
+
+        expect(deps.written).toEqual([]);
+        expect(deps.git.calls).toEqual([]);
+        expect(result).toMatchObject({ aborted: true, pushed: false });
+    });
+
+    it("does not ask for confirmation with --yes", async () => {
+        const confirm = async () => { throw new Error("should not be asked"); };
+        const deps = { ...fakeDeps(), confirm };
+
+        await expect(runRelease("3.1.0", { push: true, yes: true }, deps)).resolves.toBeDefined();
+    });
+
+    it("skips the commit when the files already carry the version", async () => {
+        // The resume case: a previous run bumped and committed, then the push
+        // failed. Re-running must reach the tag rather than dying on git's
+        // "nothing to commit".
+        const deps = fakeDeps();
+        deps.writeVersion = async (version: string) => { deps.written.push(version); };
+
+        await runRelease("3.1.0", { push: true, yes: true }, deps);
+
+        expect(deps.git.calls).toEqual(["push origin master", "tag v3.1.0", "push origin v3.1.0"]);
+    });
+
+    it("honours --remote", async () => {
+        const deps = fakeDeps();
+
+        await runRelease("3.1.0", { push: true, yes: true, remote: "upstream" }, deps);
+
+        expect(deps.git.calls).toContain("push upstream v3.1.0");
+    });
+
+    it("releases from a branch other than master", async () => {
+        const deps = fakeDeps(fakeGit({ currentBranch: () => "hotfix" }));
+
+        await runRelease("3.1.0", { push: true, yes: true }, deps);
+
+        expect(deps.git.calls).toContain("push origin hotfix");
+    });
+
+    it("rejects a version whose tag release.yml would not trigger on", async () => {
+        // Chrome accepts "3.1"; the `v3.1` tag it becomes does not match the
+        // workflow's `v*.*.*`, so pushing it would run nothing.
+        await expect(runRelease("3.1", { push: false, yes: true }, fakeDeps())).rejects.toThrow(/does not match/);
+    });
+
+    it("rejects a version Chrome itself would reject", async () => {
+        await expect(runRelease("65536.0.0", { push: false, yes: true }, fakeDeps()))
+            .rejects.toThrow(/between 0 and 65535/);
+    });
+
+    it("touches nothing when the version is rejected", async () => {
+        const deps = fakeDeps();
+
+        await expect(runRelease("3.1", { push: false, yes: true }, deps)).rejects.toThrow();
+
+        expect(deps.written).toEqual([]);
+        expect(deps.git.calls).toEqual([]);
+    });
+});
+
+describe("createGit", () => {
+
+    it("reads emptiness from git rather than parsing its output", () => {
+        const git = createGit((args: string[]) => (args[0] === "status" ? "" : "M  package.json"));
+        expect(git.isDirty()).toBe(false);
+        expect(createGit(() => " M package.json").isDirty()).toBe(true);
+    });
+
+    it("treats an empty `tag --list` as the tag not existing", () => {
+        expect(createGit(() => "").hasTag("v3.1.0")).toBe(false);
+        expect(createGit(() => "v3.1.0").hasTag("v3.1.0")).toBe(true);
+    });
+
+    it("asks the remote about the exact tag ref", () => {
+        const args: string[][] = [];
+        const git = createGit((argv: string[]) => { args.push(argv); return ""; });
+
+        git.hasRemoteTag("origin", "v3.1.0");
+
+        expect(args[0]).toEqual(["ls-remote", "--tags", "origin", "refs/tags/v3.1.0"]);
+    });
+});
+
+describe("actionsUrl", () => {
+
+    it("derives the Actions page from an SSH remote", () => {
+        expect(actionsUrl("git@github.com:SergVro/Lexin-dictionary-Chrome-Extension.git"))
+            .toBe("https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/actions");
+    });
+
+    it("derives it from an HTTPS remote", () => {
+        expect(actionsUrl("https://github.com/SergVro/Lexin-dictionary-Chrome-Extension"))
+            .toBe("https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/actions");
+    });
+
+    it("returns null for a remote it cannot read, rather than a broken link", () => {
+        expect(actionsUrl("git@gitlab.com:someone/something.git")).toBeNull();
+        expect(actionsUrl(undefined)).toBeNull();
+    });
+});

--- a/tests/unit/ReleaseVersionTests.ts
+++ b/tests/unit/ReleaseVersionTests.ts
@@ -2,7 +2,8 @@ import {
     parseTagVersion,
     validateChromeVersion,
     resolveReleaseVersion,
-    compareChromeVersions
+    compareChromeVersions,
+    toPackageVersion
 } from "../../scripts/webstore/version.js";
 
 describe("parseTagVersion", () => {
@@ -88,6 +89,26 @@ describe("resolveReleaseVersion", () => {
 
     it("rejects a well-formed tag whose version violates Chrome's rules", () => {
         expect(() => resolveReleaseVersion("v65536.0.0")).toThrow(/between 0 and 65535/);
+    });
+});
+
+describe("toPackageVersion", () => {
+
+    it("passes a three-component version through", () => {
+        expect(toPackageVersion("3.1.0")).toBe("3.1.0");
+    });
+
+    it("pads a shorter version to three components", () => {
+        expect(toPackageVersion("3")).toBe("3.0.0");
+        expect(toPackageVersion("3.1")).toBe("3.1.0");
+    });
+
+    it("drops Chrome's fourth component, which semver has no room for", () => {
+        expect(toPackageVersion("3.1.0.2")).toBe("3.1.0");
+    });
+
+    it("rejects a version Chrome itself would reject", () => {
+        expect(() => toPackageVersion("3.1.0.2.7")).toThrow(/1 to 4 components/);
     });
 });
 

--- a/tests/unit/VersionSyncTests.ts
+++ b/tests/unit/VersionSyncTests.ts
@@ -1,0 +1,154 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { applyVersion, readVersions, resolveVersionInput } from "../../scripts/webstore/bump.js";
+import { findVersionMismatches } from "../../scripts/webstore/verify-version.js";
+import { toPackageVersion } from "../../scripts/webstore/version.js";
+
+/**
+ * Guards the one version the repo declares about itself.
+ *
+ * src/manifest.json, package.json and package-lock.json used to drift: the
+ * manifest was bumped by hand at release time and package.json sat at 1.8.0
+ * through four releases, so every build and test log announced 1.8.0 long after
+ * 3.0.0 shipped. `npm run release:version -- <version>` writes all three, and
+ * this test is what makes a hand-edit of one of them fail on the pull request
+ * rather than at release time.
+ */
+describe("committed versions", () => {
+
+    it("should agree across the manifest and the npm files", async () => {
+        const versions = await readVersions();
+
+        expect(versions.package).toBe(toPackageVersion(versions.manifest));
+        expect(versions.lock).toBe(versions.package);
+        expect(versions.lockPackage).toBe(versions.package);
+    });
+});
+
+describe("findVersionMismatches", () => {
+
+    const committed = {
+        manifest: "3.1.0",
+        package: "3.1.0",
+        lock: "3.1.0",
+        lockPackage: "3.1.0"
+    };
+
+    it("reports nothing when the tag matches every file", () => {
+        expect(findVersionMismatches("v3.1.0", committed)).toEqual([]);
+    });
+
+    it("reports a manifest left behind by the tag", () => {
+        const mismatches = findVersionMismatches("v3.2.0", committed);
+        expect(mismatches).toHaveLength(3);
+        expect(mismatches[0]).toMatch(/manifest\.json/);
+    });
+
+    it("reports package.json alone when only it is stale", () => {
+        const mismatches = findVersionMismatches("v3.1.0", { ...committed, package: "1.8.0" });
+        expect(mismatches).toHaveLength(1);
+        expect(mismatches[0]).toMatch(/package\.json says "1\.8\.0"/);
+    });
+
+    it("reports a lockfile whose packages[\"\"] entry was missed", () => {
+        const mismatches = findVersionMismatches("v3.1.0", { ...committed, lockPackage: "1.8.0" });
+        expect(mismatches).toHaveLength(1);
+        expect(mismatches[0]).toMatch(/package-lock\.json/);
+    });
+
+    it("holds package.json to the three-component form of a four-component tag", () => {
+        const fourComponent = { ...committed, manifest: "3.1.0.2" };
+        expect(findVersionMismatches("v3.1.0.2", fourComponent)).toEqual([]);
+    });
+});
+
+describe("resolveVersionInput", () => {
+
+    it("takes a bare version or a tag", () => {
+        expect(resolveVersionInput("3.1.0")).toBe("3.1.0");
+        expect(resolveVersionInput("v3.1.0")).toBe("3.1.0");
+        expect(resolveVersionInput("  v3.1.0  ")).toBe("3.1.0");
+    });
+
+    it("takes Chrome's fourth component", () => {
+        expect(resolveVersionInput("3.1.0.2")).toBe("3.1.0.2");
+    });
+
+    it("rejects a version too short to make a tag release.yml triggers on", () => {
+        // `v3.1` does not match the workflow's `v*.*.*`, so a release cut with
+        // it would push a tag and then sit there doing nothing.
+        expect(() => resolveVersionInput("3.1")).toThrow(/does not match/);
+        expect(() => resolveVersionInput("3")).toThrow(/does not match/);
+    });
+
+    it("rejects a prerelease suffix, which Chrome has no notion of", () => {
+        expect(() => resolveVersionInput("3.1.0-rc1")).toThrow(/does not match/);
+    });
+});
+
+describe("applyVersion", () => {
+
+    /** A throwaway repo root holding the three files applyVersion rewrites. */
+    async function writeFixture(version: string) {
+        const root = await mkdtemp(path.join(tmpdir(), "lexin-bump-"));
+        await mkdir(path.join(root, "src"));
+
+        const write = (file: string, data: unknown) =>
+            writeFile(path.join(root, file), JSON.stringify(data, null, 2) + "\n");
+
+        await write("src/manifest.json", { manifest_version: 3, version, permissions: ["storage"] });
+        await write("package.json", { name: "lexin-chrome-extension", version });
+        await write("package-lock.json", {
+            name: "lexin-chrome-extension",
+            version,
+            packages: { "": { version } }
+        });
+
+        return root;
+    }
+
+    it("writes the version into all three files and reports what they held", async () => {
+        const root = await writeFixture("1.8.0");
+
+        const result = await applyVersion("3.1.0", root);
+
+        expect(result).toMatchObject({ manifestVersion: "3.1.0", packageVersion: "3.1.0" });
+        expect(result.previous.manifest).toBe("1.8.0");
+        expect(await readVersions(root)).toEqual({
+            manifest: "3.1.0",
+            package: "3.1.0",
+            lock: "3.1.0",
+            lockPackage: "3.1.0"
+        });
+    });
+
+    it("keeps the manifest's fourth component out of the npm files", async () => {
+        const root = await writeFixture("3.1.0");
+
+        await applyVersion("3.1.0.2", root);
+
+        expect(await readVersions(root)).toMatchObject({
+            manifest: "3.1.0.2",
+            package: "3.1.0",
+            lock: "3.1.0"
+        });
+    });
+
+    it("leaves every other field of the files it rewrites alone", async () => {
+        const root = await writeFixture("1.8.0");
+
+        await applyVersion("3.1.0", root);
+
+        const manifest = JSON.parse(await readFile(path.join(root, "src", "manifest.json"), "utf-8"));
+        expect(manifest.permissions).toEqual(["storage"]);
+        expect(manifest.manifest_version).toBe(3);
+    });
+
+    it("rejects a version Chrome would reject, before touching a file", async () => {
+        const root = await writeFixture("1.8.0");
+
+        await expect(applyVersion("65536.0.0", root)).rejects.toThrow(/between 0 and 65535/);
+        expect((await readVersions(root)).manifest).toBe("1.8.0");
+    });
+});


### PR DESCRIPTION
- Added `npm run release -- <version>` command to automate version bumping, committing, tagging, and pushing.
- Updated versioning in `src/manifest.json`, `package.json`, and `package-lock.json` to ensure consistency.
- Introduced `toPackageVersion` function to convert Chrome manifest versions to npm's semver format.
- Created `bump.js` script to handle version updates in the necessary files.
- Developed `release.js` script to manage the release process, including git operations for committing and tagging.
- Implemented `verify-version.js` to check for version mismatches before release.
- Added unit tests for version synchronization and release script functionality.
- Ensured that versioning adheres to semantic versioning principles and Chrome's versioning constraints.