### PR TITLE
feat: customizable on-page lookup modifier (Alt/Ctrl/Shift)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Swedish to other languages dictionary extension for Chrome. Powered by Lexin and
 
 - Translate Swedish words to multiple languages
 - Support for Albanian, Amharic, Arabic, Azerbaijani, Bosnian, Croatian, English, Finnish, Greek, Kurdish, Pashto, Persian, Russian, Serbian, Somali, Spanish, Swedish, Turkish, and Ukrainian
-- Quick translation via Alt + Double Click or Alt + Click
+- Quick translation via Alt + Double Click or Alt + Click (the modifier is customizable in Options)
 - Translation history with export capabilities
 - Customizable language preferences
 

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -58,6 +58,15 @@
                 </div>
             </div>
             <div class="lxField">
+                <label id="lookupModifierLabel">On-page lookup key</label>
+                <div class="lxSeg" role="radiogroup" aria-labelledby="lookupModifierLabel" id="lookupModifier">
+                    <label class="lxSegOption"><input type="radio" name="lookupModifier" value="alt" /><span>Alt / Option</span></label>
+                    <label class="lxSegOption"><input type="radio" name="lookupModifier" value="control" /><span>Ctrl</span></label>
+                    <label class="lxSegOption"><input type="radio" name="lookupModifier" value="shift" /><span>Shift</span></label>
+                </div>
+                <span class="lxHint">Hold this key while clicking selected text or double-clicking a word.</span>
+            </div>
+            <div class="lxField">
                 <label id="recordHistoryLabel">Record history</label>
                 <div class="lxSeg" role="radiogroup" aria-labelledby="recordHistoryLabel" id="recordHistory">
                     <label class="lxSegOption"><input type="radio" name="recordHistory" value="on" /><span>On</span></label>

--- a/src/scripts/common/Settings.ts
+++ b/src/scripts/common/Settings.ts
@@ -1,6 +1,9 @@
 import { IAsyncSettingsStorage } from "./Interfaces.js";
 
 const RECORD_HISTORY_KEY = "recordHistory";
+const LOOKUP_MODIFIER_KEY = "lookupModifier";
+
+export type LookupModifier = "alt" | "control" | "shift";
 
 /**
  * The extension's plain stored preferences.
@@ -34,6 +37,16 @@ class Settings {
 
     async setRecordHistory(value: boolean): Promise<void> {
         await this.settingsStorage.setItem(RECORD_HISTORY_KEY, value ? "true" : "false");
+    }
+
+    /** Modifier held while clicking a word to open the on-page translation card. */
+    async getLookupModifier(): Promise<LookupModifier> {
+        const stored = await this.settingsStorage.getItem(LOOKUP_MODIFIER_KEY);
+        return stored === "control" || stored === "shift" ? stored : "alt";
+    }
+
+    async setLookupModifier(value: LookupModifier): Promise<void> {
+        await this.settingsStorage.setItem(LOOKUP_MODIFIER_KEY, value);
     }
 }
 

--- a/src/scripts/content/ContentScript.ts
+++ b/src/scripts/content/ContentScript.ts
@@ -6,6 +6,7 @@ import * as Icons from "../util/Icons.js";
 import * as States from "../util/States.js";
 import ThemeManager, { applyTheme, Theme } from "../common/ThemeManager.js";
 import LanguageLabel, { ILanguageLabel } from "../common/LanguageLabel.js";
+import Settings, { LookupModifier } from "../common/Settings.js";
 import tokensCss from "../../css/tokens.css";
 import componentsCss from "../../css/components.css";
 import cardCss from "../../css/card.css";
@@ -42,6 +43,8 @@ class ContentScript {
     private messageHandlers: IMessageHandlers;
     private themeManager: ThemeManager;
     private languageLabel: LanguageLabel;
+    private settings: Settings;
+    private lookupModifier: LookupModifier = "alt";
 
     /**
      * What the card should say about itself, cached so a card can be built
@@ -55,11 +58,12 @@ class ContentScript {
     private clickedInsideCard = false;
 
     constructor(MessageService: IMessageService, messageHandlers: IMessageHandlers,
-                themeManager: ThemeManager, languageLabel: LanguageLabel) {
+                themeManager: ThemeManager, languageLabel: LanguageLabel, settings: Settings) {
         this.messageService = MessageService;
         this.messageHandlers = messageHandlers;
         this.themeManager = themeManager;
         this.languageLabel = languageLabel;
+        this.settings = settings;
     }
 
     getSelection(): string {
@@ -257,36 +261,29 @@ class ContentScript {
             }
             self.clickedInsideCard = false;
             const selection = self.getSelection();
-            // On Mac, check both altKey and the Option key using getModifierState
-            const isAltPressed = evt.altKey || (evt.getModifierState && evt.getModifierState("Alt"));
-            if (selection && isAltPressed) {
+            if (selection && self.isLookupModifierPressed(evt)) {
                 self.showTranslation(selection, evt);
             }
         });
 
-        // Handle double click with Alt key (for Mac compatibility)
-        // Note: On Mac, we need to check modifier state differently
-        // Also listen on mousedown to catch Alt key state before double-click
-        let altKeyDown = false;
+        // Keep a keyboard-state fallback because some platforms omit the modifier
+        // flag from the synthesized second click in a double-click gesture.
+        let modifierKeyDown = false;
         document.addEventListener("keydown", function (e: KeyboardEvent) {
-            if (e.key === "Alt" || e.key === "Option" || e.altKey) {
-                altKeyDown = true;
+            if (self.isLookupModifierPressed(e)) {
+                modifierKeyDown = true;
             }
         });
         document.addEventListener("keyup", function (e: KeyboardEvent) {
-            if (e.key === "Alt" || e.key === "Option" || !e.altKey) {
-                altKeyDown = false;
+            if (!self.isLookupModifierPressed(e)) {
+                modifierKeyDown = false;
             }
         });
 
         document.addEventListener("dblclick", function (evt: MouseEvent) {
-            // On Mac, check both altKey and the Option key using getModifierState
-            // Also check our tracked altKeyDown state as fallback
-            const isAltPressed = evt.altKey ||
-                                (evt.getModifierState && evt.getModifierState("Alt")) ||
-                                altKeyDown;
+            const isModifierPressed = self.isLookupModifierPressed(evt) || modifierKeyDown;
 
-            if (isAltPressed) {
+            if (isModifierPressed) {
                 // Prevent default double-click behavior (like text selection)
                 evt.preventDefault();
                 evt.stopPropagation();
@@ -327,6 +324,20 @@ class ContentScript {
         });
     }
 
+    private isLookupModifierPressed(evt: MouseEvent | KeyboardEvent): boolean {
+        if (this.lookupModifier === "control") {
+            return evt.ctrlKey || evt.getModifierState?.("Control") === true;
+        }
+        if (this.lookupModifier === "shift") {
+            return evt.shiftKey || evt.getModifierState?.("Shift") === true;
+        }
+        return evt.altKey || evt.getModifierState?.("Alt") === true;
+    }
+
+    async refreshLookupModifier(): Promise<void> {
+        this.lookupModifier = await this.settings.getLookupModifier();
+    }
+
     /**
      * Escape dismisses the card.
      *
@@ -342,7 +353,8 @@ class ContentScript {
         });
     }
 
-    initialize() {
+    async initialize(): Promise<void> {
+        await this.refreshLookupModifier();
         this.handleGetSelection();
         this.subscribeOnClicks();
         this.subscribeOnKeyboard();

--- a/src/scripts/content/content.ts
+++ b/src/scripts/content/content.ts
@@ -3,6 +3,7 @@ import MessageHandlers from "../messaging/MessageHandlers.js";
 import ContentScript from "./ContentScript.js";
 import ThemeManager from "../common/ThemeManager.js";
 import LanguageLabel from "../common/LanguageLabel.js";
+import Settings from "../common/Settings.js";
 import DictionaryFactory from "../dictionary/DictionaryFactory.js";
 import { createChromeStorage } from "../common/ChromeStorageAdapter.js";
 
@@ -22,6 +23,15 @@ const contentScript = new ContentScript(
     messageService,
     messageHandlers,
     new ThemeManager(settingsStorage),
-    new LanguageLabel(settingsStorage, languages)
+    new LanguageLabel(settingsStorage, languages),
+    new Settings(settingsStorage)
 );
 contentScript.initialize();
+
+// Options can be open beside an existing page. Apply a newly selected key without
+// requiring that page (and every frame in it) to be reloaded.
+chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName === "local" && changes.lookupModifier) {
+        contentScript.refreshLookupModifier();
+    }
+});

--- a/src/scripts/options/OptionsPage.ts
+++ b/src/scripts/options/OptionsPage.ts
@@ -4,7 +4,7 @@ import { showToast } from "../util/Toast.js";
 import { fold } from "../util/Combobox.js";
 import LanguageManager from "../common/LanguageManager.js";
 import ThemeManager, { Appearance, applyTheme } from "../common/ThemeManager.js";
-import Settings from "../common/Settings.js";
+import Settings, { LookupModifier } from "../common/Settings.js";
 import { ILanguage } from "../common/Interfaces.js";
 
 class OptionsPage {
@@ -172,6 +172,12 @@ class OptionsPage {
         if (recordInput) {
             recordInput.checked = true;
         }
+
+        const modifier = await this.settings.getLookupModifier();
+        const modifierInput = DomUtils.$(`#lookupModifier input[value='${modifier}']`) as HTMLInputElement;
+        if (modifierInput) {
+            modifierInput.checked = true;
+        }
     }
 
     private subscribeOnEvents(): void {
@@ -196,6 +202,12 @@ class OptionsPage {
         DomUtils.$("#recordHistory")?.addEventListener("change", async (e: Event) => {
             const recording = (e.target as HTMLInputElement).value === "on";
             await this.settings.setRecordHistory(recording);
+            showToast("Options saved");
+        });
+
+        DomUtils.$("#lookupModifier")?.addEventListener("change", async (e: Event) => {
+            const modifier = (e.target as HTMLInputElement).value as LookupModifier;
+            await this.settings.setLookupModifier(modifier);
             showToast("Options saved");
         });
     }

--- a/tests/unit/SettingsTests.ts
+++ b/tests/unit/SettingsTests.ts
@@ -32,4 +32,22 @@ describe("Settings", () => {
             expect(await settings.getRecordHistory()).toBe(true);
         });
     });
+
+    describe("lookupModifier", () => {
+        it("should default to Alt", async () => {
+            expect(await settings.getLookupModifier()).toBe("alt");
+        });
+
+        it("should round-trip supported alternatives", async () => {
+            await settings.setLookupModifier("control");
+            expect(await settings.getLookupModifier()).toBe("control");
+            await settings.setLookupModifier("shift");
+            expect(await settings.getLookupModifier()).toBe("shift");
+        });
+
+        it("should fall back to Alt for an unknown stored value", async () => {
+            await storage.setItem("lookupModifier", "meta");
+            expect(await settings.getLookupModifier()).toBe("alt");
+        });
+    });
 });


### PR DESCRIPTION
### Motivation

- Make the on-page translation gesture configurable so users on different platforms or with different workflows can choose the modifier key that triggers the in-page lookup. 
- Preserve existing behaviour by keeping Alt as the backward-compatible default and defensively handle unknown stored values.

### Description

- Added an `On-page lookup key` control to the Options page letting users choose `Alt / Option`, `Ctrl`, or `Shift`, and wired it into the options UI. 
- Persisted the choice in settings via a new `lookupModifier` key and corresponding `getLookupModifier`/`setLookupModifier` APIs in `Settings`. 
- Updated the content script to consult the configured modifier when deciding whether a click or double-click should open the translation card, including a keyboard-state fallback and a helper `isLookupModifierPressed`. 
- Applied changes to already-open pages by listening for Chrome storage changes and refreshing the content script's modifier, and added unit tests covering defaults, persistence, and invalid stored values.

### Testing

- Ran the focused unit tests for settings: `tests/unit/SettingsTests.ts` and they passed (6 tests). 
- Ran the full test suite: `npm test` completed successfully (24 test files, 259 tests passed). 
- Performed static checks: `npm run typecheck` and `npm run lint` both succeeded. 
- Verified build: `npm run build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71e7860db0832fb971462028e29c63)