### PR TITLE
feat: let the reader choose the lookup trigger

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,9 +9,18 @@ inline on the page being read, or in the extension's own pages.
 ### Surfaces
 
 **Translation Card**:
-The floating card shown over a web page when the reader Alt+Clicks a word. Rendered
-by the content script into a shadow root so the host page cannot style it.
+The floating card shown over a web page when the reader performs the Lookup Trigger
+on a word. Rendered by the content script into a shadow root so the host page cannot
+style it.
 _Avoid_: popup, tooltip, overlay, bubble
+
+**Lookup Trigger**:
+The modifier a reader holds while clicking or double-clicking a word to open a
+Translation Card. Alt by default, and theirs to change - ChromeOS and some Linux
+desktops consume Alt+click before the page is sent anything. Stored as
+`triggerModifier`. Distinct from the *keyboard shortcut*, which Chrome owns and binds
+at chrome://extensions/shortcuts.
+_Avoid_: hotkey, hot key, shortcut (for the modifier), accelerator
 
 **Action Popup**:
 The panel that opens from the extension's toolbar icon, where a word can be typed

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,9 @@ Swedish to other languages dictionary extension for Chrome. Powered by Lexin and
 
 - Translate Swedish words to multiple languages
 - Support for Albanian, Amharic, Arabic, Azerbaijani, Bosnian, Croatian, English, Finnish, Greek, Kurdish, Pashto, Persian, Russian, Serbian, Somali, Spanish, Swedish, Turkish, and Ukrainian
-- Quick translation via Alt + Double Click or Alt + Click
+- Quick translation via Alt + Double Click or Alt + Click, with Ctrl and Shift
+  offered as alternatives for desktops that keep Alt for themselves
+- A rebindable keyboard shortcut that translates the selected word
 - Translation history with export capabilities
 - Customizable language preferences
 
@@ -154,7 +156,12 @@ The extension includes unit tests (currently disabled during migration). To re-e
 ### Quick Translation
 1. Alt + Double Click on any word on a webpage
 2. Or select a word and Alt + Click
-3. Or select a word and click the extension icon
+3. Or select a word and press the keyboard shortcut
+4. Or select a word and click the extension icon
+
+The modifier is configurable in Options — ChromeOS and some Linux desktops intercept
+Alt+click before the page ever sees it. The keyboard shortcut is bound in Chrome, at
+chrome://extensions/shortcuts.
 
 ### Translation History
 - Access via the popup window or options page
@@ -165,6 +172,8 @@ The extension includes unit tests (currently disabled during migration). To re-e
 - Set default language
 - Enable/disable specific languages
 - Customize which languages appear in dropdowns
+- Choose the modifier held to look a word up (Alt, Ctrl or Shift)
+- Open Chrome's shortcuts page to bind the keyboard shortcut
 
 ## Releasing
 

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -117,9 +117,32 @@ broken code on the first attempt**:
   the final card now; the mechanism it was meant to pin is covered by a single-click
   test instead, where a wrong lookup has nothing to hide behind.
 
-That last one is worth stating plainly as a **pre-existing limitation this work
-uncovered but did not fix**: `HistoryManager` does read-modify-write with no
-serialisation, so two lookups a few milliseconds apart can lose an entry.
+A third round found two more:
+
+- **The page's default survived a trigger click that found nothing to look up.** The
+  click path returned on an empty selection *before* suppressing the default — which
+  is exactly the first click of a double-click on a word. Every trigger does something
+  to a link on that click, so the page acted before the lookup had decided what the
+  word was. Suppression now happens as soon as the modifier matches, before any return.
+- **Elided elements ran words together.** `<br>` reports as inline and carries no text,
+  so flowing the surrounding text together read `bil<br>hund` as `bilhund` and looked
+  *that* up. Line breaks and nested blocks now contribute a newline instead of nothing.
+
+## Pre-existing limitations this work uncovered but did not fix
+
+- **`HistoryManager` does read-modify-write with no serialisation**, so two lookups a
+  few milliseconds apart can lose an entry. This is what let one regression test pass
+  against broken code.
+- **A linked word cannot be double-clicked with Alt.** Chrome aborts the gesture after
+  the second `mousedown` on an `<a>` with Alt held — no second `click`, no `dblclick`,
+  with or without the suppression above. Verified by instrumenting the page. Looking a
+  linked word up has therefore never worked on the Alt path, and the fix above does not
+  change it.
+
+That second one is why the suppression is tested on the event (`defaultPrevented`)
+rather than on its consequence. The consequence differs by modifier and platform, and
+two of the three are not observable in the harness at all: Ctrl is not offered on a Mac,
+and Shift's own mousedown suppression masks it.
 
 ## Consequences worth knowing
 

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -1,0 +1,119 @@
+# Let the reader choose the lookup trigger
+
+Alt + click was the only way to open a Translation Card for the extension's whole
+life. Two issues said it did not work, on two platforms, and neither was a bug in the
+extension:
+
+- **[#21] ChromeOS.** Alt + click *is* the secondary click on a Chromebook — Google
+  documents it as the way to right-click. Ash, the window server, consumes it before
+  the renderer is sent anything, so the page receives a `contextmenu` and never a
+  left `click` carrying `altKey`. Google is also midway through moving this to
+  `Search + click` behind a flag, so the behaviour varies by ChromeOS version.
+- **[#15] Linux.** GNOME's Mutter grabs Alt + click for window-move
+  (`org.gnome.desktop.wm.preferences.mouse-button-modifier`).
+
+No content script can win an event it is never sent. The only fix available to the
+extension is to stop hardcoding the trigger, which is [#17].
+
+Two routes now exist, and they answer different halves of the problem:
+
+1. **A configurable modifier** — Alt (default), Ctrl or Shift, in Options. Keeps the
+   fast double-click-a-word flow and lets a reader route around whatever their
+   desktop takes.
+2. **A `chrome.commands` keyboard shortcut** — `translate-selection`, suggested at
+   `Ctrl+Shift+L`. A browser-level shortcut is the one trigger no desktop can
+   intercept, and Chrome supplies the rebinding UI at `chrome://extensions/shortcuts`
+   for free, so the extension ships no key-capture widget of its own.
+
+## What hand-testing changed
+
+Two defects turned up on macOS that the obvious design would have shipped:
+
+- **Ctrl + double-click opened the context menu.** macOS defines Ctrl + click as the
+  secondary click, so Chrome raises `contextmenu` off the mousedown and suppresses the
+  `click` entirely. No listener ordering recovers it. **Ctrl is therefore not offered
+  on a Mac** (`availableModifiers`), and `Settings.getTriggerModifier` falls back to
+  Alt if it somehow finds `ctrl` stored there. A Mac needs no escape hatch anyway:
+  Option + click, the default, works fine.
+- **Shift + click expanded the selection.** Shift + click's own meaning is "extend the
+  selection from the existing anchor", so after one lookup the anchor sat on the first
+  word and the next Shift + click selected everything in between — and looked *that*
+  up. This has two halves and needed two fixes:
+  - the double-click path naming its word by **position** (`wordAtPoint`) rather than
+    by reading the selection — which fixes *which word gets looked up*;
+  - `preventDefault()` on `mousedown`, which stops the selection growing at the source
+    (selection changes are a mousedown default) — which fixes *the page visibly
+    selecting half a paragraph*.
+
+  `tests/e2e/trigger.spec.ts` covers them as two separate tests, because each passes
+  while the other's fix is removed. That was found by removing each and watching.
+
+  **The mousedown `preventDefault` is applied for Shift only.** Alt and Ctrl replace
+  the selection rather than extending it, so they have nothing to fix — and
+  suppressing their default would throw away the browser's own double-click word
+  selection, which the dblclick handler still wants as a fallback. That fallback is
+  not theoretical: `caretRangeFromPoint` answers for points inside the viewport only,
+  so `wordAtPoint` returns nothing for a word below the fold. A reader cannot click a
+  word they cannot see, but a test harness can, and doing it unconditionally broke six
+  style-isolation tests before this was narrowed. Leaving the default alone for the
+  shipped trigger also means Alt behaves exactly as it always has.
+
+## Consequences worth knowing
+
+- **The two mouse paths now mean different things.** Double-click asks "the word I am
+  pointing at" — position is the source of truth. Single click asks "what I selected"
+  — the selection is. That makes the double-click gesture immune to every selection
+  oddity, not just Shift's, including a stale selection left by a previous lookup.
+- **`wordAtPoint` moved from fallback to primary**, which put two latent bugs on the
+  hot path and so got them fixed: `\w` is ASCII-only and turned `björn` into `bjrn` in
+  a *Swedish* dictionary, and the `caretPositionFromPoint` branch read a
+  `CaretPosition` as if it were a `Range`.
+- **Matching is exclusive.** `Alt+Shift+click` used to open a card and no longer does.
+  With three modifiers to choose between, a permissive match would fire
+  `Ctrl+Shift+click` for a Ctrl reader *and* a Shift reader, and compound chords are
+  where browsers and pages put meanings of their own — Cmd+click opens a link in a new
+  tab, and AltGr on Windows is literally Ctrl+Alt.
+- **`preventDefault()` on a matched click** suppresses Alt+click-downloads-a-link and
+  Ctrl+click-opens-a-background-tab, and the Shift-only mousedown one additionally
+  costs focus-on-click and drag-start — all only while the trigger modifier is held,
+  so ordinary interaction is untouched.
+- **The `altKeyDown` keyboard tracker was deleted.** It existed as a "Mac
+  compatibility" fallback, and it was stale state by construction: `keyup` is never
+  delivered if the key is released while the document lacks focus, so one Alt+Tab left
+  it stuck `true` and *any* plain double-click opened a card. Generalising it to three
+  modifiers would have made Shift+Tab and Ctrl+Tab do the same. If a Mac regression
+  ever does appear, the correct hedge is a `mousedown` snapshot, which cannot go stale
+  because a mousedown must occur inside the gesture.
+- **This is the extension's only `chrome.storage.onChanged` listener**, and it watches
+  one key. Every other setting is re-read by the action that displays it, so staleness
+  heals itself after one card. The trigger cannot work that way: a reader changes it
+  precisely because their desktop intercepts the current one, so the page they were
+  reading has no way to open a card and re-read on its own. Waiting would look exactly
+  like the setting doing nothing. The cost is one listener per frame, firing on every
+  local-storage write; the body is a single key check.
+- **The shortcut is silent when nothing is selected.** Falling back to opening the
+  Action Popup was rejected: on `chrome://` pages, the Web Store and the PDF viewer no
+  frame ever answers, so the panel would fly open on every press. The Options page
+  shows the live binding (`chrome.commands.getAll`) instead, which also covers the
+  case where another extension already holds `Ctrl+Shift+L` and Chrome silently left
+  ours unassigned.
+- **`commands` is a manifest key, not a permission.** `permissions` is still exactly
+  `["storage", "offscreen"]` and the install warning is unchanged. `ManifestTests`
+  says so explicitly so nobody "fixes" the permission list to match.
+
+## What the tests cannot prove
+
+Playwright drives Chrome over CDP, which injects input *below* the layer where Ash and
+Mutter take Alt + click. **The original bug is not reproducible in the test suite on
+any platform**, and no test will ever fail because of it. The suite proves the trigger
+is configurable, that a non-default modifier works where the default does not, that a
+change reaches an already-open tab, that dismissal still works, and that the copy
+tells the truth. Chrome's dispatch of a keystroke to `onCommand` is likewise not
+reachable — `page.keyboard.press` goes to the renderer — so the command tests drive
+the worker's handler directly and say so.
+
+The interception itself is verified by hand, on the platform.
+
+[#15]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/15
+[#17]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/17
+[#21]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/21

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -58,6 +58,38 @@ Two defects turned up on macOS that the obvious design would have shipped:
   style-isolation tests before this was narrowed. Leaving the default alone for the
   shipped trigger also means Alt behaves exactly as it always has.
 
+## What code review changed
+
+Three defects Codex found on the PR, all of them real:
+
+- **Two documents answered one keystroke.** Every document on the focused chain
+  reports `hasFocus`, and each keeps whatever it had selected last — so a reader who
+  selected a word in the page and then another inside an iframe left both claiming a
+  live selection, and both opened a card and filed a history entry. What names a
+  single frame is being the *deepest* focused one: a document whose own
+  `activeElement` is a frame has handed focus on.
+- **A word split across inline elements came back in pieces.** `h<em>u</em>nd`
+  renders as one word and a reader double-clicks it as one, but it is three text
+  nodes, and `wordAtPoint` scans only the node under the pointer — returning `u`.
+  Fixed by preferring the browser's own selection wherever it was allowed to make
+  one: it spans inline elements, and its word segmentation knows more about language
+  than a regular expression ever will. Position remains the answer where the
+  selection was suppressed, and the fallback where position cannot answer.
+- **A double-click looked its word up twice.** A double-click arrives as click,
+  click, dblclick, and the second click reached the lookup too. This was *pre-existing*
+  — every Alt+double-click had been making two dictionary requests and filing two
+  identical history entries — and was found only because the review prompted a look.
+  Fixed by ignoring clicks carrying `detail > 1`.
+  - Under Shift there is a second half: suppressing the mousedown default keeps an
+    older selection alive, so the *first* click of a double-click would look *that*
+    up. Fixed by deferring the click lookup and cancelling it when a double-click
+    follows. Only the Shift path waits, so the shipped trigger costs nothing.
+
+Each has a regression test, and each test was verified by removing its fix and
+watching it fail. That mattered: two of them passed at first against the broken code,
+because a lookup's card is dismissed by the next one and leaves no trace on the page.
+Both now count history entries instead, which is where the harm actually lands.
+
 ## Consequences worth knowing
 
 - **The two mouse paths now mean different things.** Double-click asks "the word I am

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -154,10 +154,10 @@ two ways markup and rendering come apart, and each needed its own rule.
 
 ## Pre-existing limitations this work uncovered but did not fix
 
-- **`HistoryManager` does read-modify-write with no serialisation**, so two lookups a
-  few milliseconds apart can lose an entry. This is what let one regression test pass
-  against broken code.
-- **A linked word cannot be double-clicked with Alt.** Chrome aborts the gesture after
+- **`HistoryManager` does read-modify-write with no serialisation** ([#68]), so two
+  lookups a few milliseconds apart can lose an entry. This is what let one regression
+  test pass against broken code.
+- **A linked word cannot be double-clicked with Alt** ([#69]). Chrome aborts the gesture after
   the second `mousedown` on an `<a>` with Alt held — no second `click`, no `dblclick`,
   with or without the suppression above. Verified by instrumenting the page. Looking a
   linked word up has therefore never worked on the Alt path, and the fix above does not
@@ -225,5 +225,7 @@ the worker's handler directly and say so.
 The interception itself is verified by hand, on the platform.
 
 [#15]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/15
+[#68]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/68
+[#69]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/69
 [#17]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/17
 [#21]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/21

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -15,230 +15,188 @@ extension:
 No content script can win an event it is never sent. The only fix available to the
 extension is to stop hardcoding the trigger, which is [#17].
 
-Two routes now exist, and they answer different halves of the problem:
+## The decision
+
+Two routes, answering different halves of the problem:
 
 1. **A configurable modifier** — Alt (default), Ctrl or Shift, in Options. Keeps the
-   fast double-click-a-word flow and lets a reader route around whatever their
-   desktop takes.
+   fast double-click-a-word flow and lets a reader route around whatever their desktop
+   takes.
 2. **A `chrome.commands` keyboard shortcut** — `translate-selection`, suggested at
    `Ctrl+Shift+L`. A browser-level shortcut is the one trigger no desktop can
    intercept, and Chrome supplies the rebinding UI at `chrome://extensions/shortcuts`
    for free, so the extension ships no key-capture widget of its own.
 
-## What hand-testing changed
+Alt stays the default, so a reader who was not blocked sees no change.
 
-Two defects turned up on macOS that the obvious design would have shipped:
+## Which modifiers are offered
 
-- **Ctrl + double-click opened the context menu.** macOS defines Ctrl + click as the
-  secondary click, so Chrome raises `contextmenu` off the mousedown and suppresses the
-  `click` entirely. No listener ordering recovers it. **Ctrl is therefore not offered
-  on a Mac** (`availableModifiers`), and `Settings.getTriggerModifier` falls back to
-  Alt if it somehow finds `ctrl` stored there. A Mac needs no escape hatch anyway:
-  Option + click, the default, works fine.
-- **Shift + click expanded the selection.** Shift + click's own meaning is "extend the
-  selection from the existing anchor", so after one lookup the anchor sat on the first
-  word and the next Shift + click selected everything in between — and looked *that*
-  up. This has two halves and needed two fixes:
-  - the double-click path naming its word by **position** (`wordAtPoint`) rather than
-    by reading the selection — which fixes *which word gets looked up*;
-  - `preventDefault()` on `mousedown`, which stops the selection growing at the source
-    (selection changes are a mousedown default) — which fixes *the page visibly
-    selecting half a paragraph*.
+**Ctrl is not offered on a Mac** (`availableModifiers`). macOS defines Ctrl + click as
+the secondary click, so Chrome raises `contextmenu` off the mousedown and suppresses
+the `click` entirely — no listener ordering recovers it. `Settings.getTriggerModifier`
+falls back to Alt if it finds `ctrl` stored there anyway. A Mac needs no escape hatch:
+Option + click, the default, works fine.
 
-  `tests/e2e/trigger.spec.ts` covers them as two separate tests, because each passes
-  while the other's fix is removed. That was found by removing each and watching.
+**Matching is exclusive** — `Alt+Shift+click` used to open a card and no longer does.
+With three modifiers to choose between, a permissive match would fire
+`Ctrl+Shift+click` for a Ctrl reader *and* a Shift reader, and compound chords are
+where browsers and pages put meanings of their own: Cmd+click opens a link in a new
+tab, and AltGr on Windows is literally Ctrl+Alt.
 
-  **The mousedown `preventDefault` is applied for Shift only.** Alt and Ctrl replace
-  the selection rather than extending it, so they have nothing to fix — and
-  suppressing their default would throw away the browser's own double-click word
-  selection, which the dblclick handler still wants as a fallback. That fallback is
-  not theoretical: `caretRangeFromPoint` answers for points inside the viewport only,
-  so `wordAtPoint` returns nothing for a word below the fold. A reader cannot click a
-  word they cannot see, but a test harness can, and doing it unconditionally broke six
-  style-isolation tests before this was narrowed. Leaving the default alone for the
-  shipped trigger also means Alt behaves exactly as it always has.
+## Naming the word under the pointer
 
-## What code review changed
+**The two mouse paths mean different things.** Double-click asks "the word I am
+pointing at" — position is the source of truth. Single click asks "what I selected" —
+the selection is. That makes the double-click gesture immune to every selection oddity,
+including a stale selection left by a previous lookup.
 
-Three defects Codex found on the PR, all of them real:
+Where the browser was allowed to make the selection, **its own is preferred**: it spans
+inline elements, and its word segmentation knows more about language than a regular
+expression ever will. `wordAtPoint` is the answer where the selection was suppressed
+(see below), and the fallback where position cannot answer — `caretRangeFromPoint`
+resolves points inside the viewport only, so a word below the fold has no caret.
 
-- **Two documents answered one keystroke.** Every document on the focused chain
-  reports `hasFocus`, and each keeps whatever it had selected last — so a reader who
-  selected a word in the page and then another inside an iframe left both claiming a
-  live selection, and both opened a card and filed a history entry. What names a
-  single frame is being the *deepest* focused one: a document whose own
-  `activeElement` is a frame has handed focus on.
-- **A word split across inline elements came back in pieces.** `h<em>u</em>nd`
-  renders as one word and a reader double-clicks it as one, but it is three text
-  nodes, and `wordAtPoint` scans only the node under the pointer — returning `u`.
-  Fixed by preferring the browser's own selection wherever it was allowed to make
-  one: it spans inline elements, and its word segmentation knows more about language
-  than a regular expression ever will. Position remains the answer where the
-  selection was suppressed, and the fallback where position cannot answer.
-- **A double-click looked its word up twice.** A double-click arrives as click,
-  click, dblclick, and the second click reached the lookup too. This was *pre-existing*
-  — every Alt+double-click had been making two dictionary requests and filing two
-  identical history entries — and was found only because the review prompted a look.
-  Fixed by ignoring clicks carrying `detail > 1`.
-  - Under Shift there is a second half: suppressing the mousedown default keeps an
-    older selection alive, so the *first* click of a double-click would look *that*
-    up. The click path now requires the click to have landed **on** the selection.
+### The rule `wordAtPoint` follows
 
-A second round found three more:
+**The walk has to agree with what the reader sees. Every disagreement shows up as a
+lookup for a word that is not on the page.** Markup and rendering come apart in three
+ways, and reasoning about the DOM finds none of them:
 
-- **Split words were still broken under Shift**, whose selection is suppressed and so
-  had no browser selection to defer to. `wordAtPoint` now reads the whole run of text
-  a word sits in — walking the inline elements inside the nearest block — so
-  `h<em>u</em>nd` is one word to it too. This matters more than it first appears:
-  pages split words whenever they emphasise, link or highlight part of one, which
-  search results do to almost every word they show.
-- **A deferred lookup outlived its dismissal.** The first fix for the stale-selection
-  case waited out a grace period before looking up; Escape or a click elsewhere during
-  that window removed the card but left the timer running, so it reopened.
-- **The grace period was guesswork.** It assumed a 500ms double-click interval, but
-  the interval is configured by the reader and Chrome does not expose it — Windows
-  allows up to 5 seconds.
+| Markup | Reader sees | Naive walk collects |
+|---|---|---|
+| `h<em>u</em>nd` | one word | `u` — one text node under the pointer |
+| `bil<br>hund`, `bil<img>hund` | two words | `bilhund` — the gap carries no text |
+| `h<span hidden>ZZZ</span>und` | one word | `h`/`und` — `display:none` is not inline |
+| `bil<svg><title>ikon</title></svg>hund` | two words | `bilikonhund` — a name, not text |
 
-The last two dissolved rather than being patched. **Where the click landed** answers
-the same question with no interval in it at all: a reader looking their selection up
-clicks *on* it, and a reader starting a double-click elsewhere does not. That is known
-at once, so the timer, the grace constant and the pending-lookup state all went away,
-and the select-then-click flow stopped costing a wait.
+So `wordAtPoint` reads the whole run of text a word sits in — walking the inline
+elements inside the nearest block — and decides what ends that run **geometrically**,
+never against a list of tag names:
 
-Each finding has a regression test, and each test was verified by removing its fix and
-watching it fail. That mattered more than expected — **three tests passed against the
-broken code on the first attempt**:
+- **Renders nothing** (`display: none`) → skipped outright, contributing neither text
+  nor a boundary. This also keeps a mid-sentence `<script>`'s source out of the text.
+- **Takes up room but draws no text** → a boundary. Asked as
+  `getBoundingClientRect().width > 0` plus a `Range` around each text node to see
+  whether any of it is drawn.
+- **A `<br>`, or anything not inline** → a boundary, and not descended into.
 
-- two counted cards, but a lookup dismisses the previous card before opening its own,
-  so a duplicate leaves exactly one card behind and is invisible from the page. They
-  count history entries now.
-- one counted history entries for a *double-click*, where two lookups fire close
-  enough together to read the same store and overwrite one another. It asserts only
-  the final card now; the mechanism it was meant to pin is covered by a single-click
-  test instead, where a wrong lookup has nothing to hide behind.
+Both halves of that middle test are load-bearing, because the obvious simplifications
+are wrong in opposite directions: with no rule at all an icon is elided and
+`bil<img>hund` reads as one word; with a naive "every textless element separates" rule,
+`h<span></span>und` breaks into `und`. Geometry also gets `<svg>`, `<canvas>`,
+`<video>`, form controls, custom elements and `::before` icons right without naming any
+of them, and leaves `<wbr>` alone.
 
-A third round found two more:
+Moving `wordAtPoint` from fallback to primary put two latent bugs on the hot path and
+so got them fixed: `\w` is ASCII-only and turned `björn` into `bjrn` in a *Swedish*
+dictionary, and the `caretPositionFromPoint` branch read a `CaretPosition` as if it
+were a `Range`.
 
-- **The page's default survived a trigger click that found nothing to look up.** The
-  click path returned on an empty selection *before* suppressing the default — which
-  is exactly the first click of a double-click on a word. Every trigger does something
-  to a link on that click, so the page acted before the lookup had decided what the
-  word was. Suppression now happens as soon as the modifier matches, before any return.
-- **Elided elements ran words together.** `<br>` reports as inline and carries no text,
-  so flowing the surrounding text together read `bil<br>hund` as `bilhund` and looked
-  *that* up. Line breaks and nested blocks now contribute a newline instead of nothing.
+## Keeping the trigger out of the page's way
 
-A fourth round found the same class of bug once more, in the elements that carry no
-text but do take up room: an icon between two words left `bil<img>hund` reading as one.
+**The default is suppressed as soon as the modifier matches**, ahead of every early
+return. Once the modifier is held the gesture is the extension's, and the page does not
+also get it — every trigger does something to a link (Ctrl+click opens a background
+tab, Alt+click downloads, Shift+click opens a window), and the first click of a
+double-click on a linked word would otherwise act before the lookup had decided what
+the word was.
 
-The rule is **"does it take up room"** — `getBoundingClientRect().width > 0` on a
-textless inline element — rather than a list of tag names. That is the question the
-reader's eye is answering, and asking it directly gets `<img>`, `<svg>`, form controls
-and custom elements right without naming any of them, leaves `<wbr>` and zero-width
-wrappers alone, and catches an icon drawn by a `::before` rule whose glyph never
-appears in `textContent` at all. Its test pins both directions, because the obvious
-correction is wrong in the other one: with no rule the icon is elided and the lookup
-reads `bilhund`; with the naive "every textless element separates" rule,
-`h<span></span>und` breaks into `und`.
+**`preventDefault()` on `mousedown` is applied for Shift only.** Shift + click's own
+meaning is "extend the selection from the existing anchor", so without it a second
+lookup selects everything between the two words and highlights half a paragraph. Alt
+and Ctrl replace the selection rather than extending it, so they have nothing to fix —
+and suppressing their default would throw away the browser's own double-click word
+selection, which the dblclick path still wants. Leaving it alone for the shipped
+trigger also means Alt behaves exactly as it always has.
 
-A fifth round found the mirror of it: a *hidden* element renders no box, and
-`display: none` fails every test for flowing inline, so `h<span hidden></span>und` was
-read as a block boundary and cut the visible word in half. Nothing rendered is now
-skipped outright - contributing neither text nor a boundary - which also keeps the
-source of a `<script>` left mid-sentence out of the flowed text.
+The cost, for Shift only: a trigger-click no longer focuses what it lands on and cannot
+start a drag.
 
-A sixth round found the third variant: an accessible `<svg><title>ikon</title></svg>`
-icon *has* text, so the textless test let it through and the walk read the page as
-`bilikonhund`. A `<title>` is a name for screen readers, and a `<canvas>`'s fallback
-is the same; both appear in `textContent` and both measure zero.
+## Telling a click from the first half of a double-click
 
-The pattern across those three rounds is worth naming, because it was the thing I kept
-missing rather than three separate oversights: **this walk has to agree with what the
-reader sees, and every disagreement shows up as a lookup for a word that is not on the
-page.** Markup and rendering come apart in three ways - text present but invisible,
-space taken but textless, and text present but not drawn - and reasoning about the DOM
-finds none of them.
+A double-click arrives as click, click, dblclick.
 
-So both halves of the question are asked geometrically: *does it take up room*
-(`getBoundingClientRect().width`) and *is any of its text drawn* (a `Range` around each
-text node, stopping at the first that measures). No list of tag names appears anywhere,
-which is what makes it right for `<svg>`, `<canvas>`, `<video>`, form controls, custom
-elements and `::before` icons alike - none of which are named.
+- **Clicks carrying `detail > 1` are ignored** — the word they would look up is the
+  dblclick handler's to name. This also fixes a pre-existing defect: every
+  Alt+double-click had been making two dictionary requests and filing two identical
+  history entries.
+- **Under Shift, a click must have landed *on* the selection** to look it up. The
+  mousedown suppression keeps an older selection alive, so the first click of a
+  double-click aimed elsewhere would otherwise look up a word the reader chose some
+  time ago. Where the click landed answers this at once — a reader looking their
+  selection up clicks on it, and a reader starting a double-click elsewhere does not.
 
-## Pre-existing limitations this work uncovered but did not fix
+Waiting out a grace period to see whether a double-click follows was tried and
+rejected: the double-click interval is the reader's to configure and Chrome does not
+expose it (Windows allows up to five seconds), so any constant is a guess, and a
+generous one makes the select-then-click flow feel broken.
+
+## The keyboard shortcut
+
+- **`commands` is a manifest key, not a permission.** `permissions` is still exactly
+  `["storage", "offscreen"]` and the install warning is unchanged. `ManifestTests` says
+  so explicitly, so nobody "fixes" the permission list to match.
+- **Only the deepest focused frame answers.** Every document on the focused chain
+  reports `hasFocus`, and each keeps whatever it had selected last — so a word selected
+  in the page and another inside an iframe would otherwise have both opening a card and
+  filing a history entry. A document whose own `activeElement` is a frame has handed
+  focus on and stays quiet.
+- **Silent when nothing is selected.** Falling back to opening the Action Popup was
+  rejected: on `chrome://` pages, the Web Store and the PDF viewer no frame ever
+  answers, so the panel would fly open on every press. The Options page shows the live
+  binding (`chrome.commands.getAll`) instead, which also covers Chrome silently leaving
+  the suggested combination unassigned because another extension holds it.
+
+## Picking a change up without a reload
+
+**This is the extension's only `chrome.storage.onChanged` listener**, and it watches one
+key. Every other setting is re-read by the action that displays it, so staleness heals
+itself after one card. The trigger cannot work that way: a reader changes it precisely
+because their desktop intercepts the current one, so the page they were reading has no
+way to open a card and re-read on its own. Waiting would look exactly like the setting
+doing nothing.
+
+The cost is one listener per frame, firing on every local-storage write; the body is a
+single key check.
+
+## The `altKeyDown` tracker was deleted
+
+A "Mac compatibility" fallback, and stale state by construction: `keyup` is never
+delivered if the key is released while the document lacks focus, so one Alt+Tab left it
+stuck `true` and *any* plain double-click opened a card. Generalising it to three
+modifiers would have made Shift+Tab and Ctrl+Tab do the same. Should a Mac regression
+appear, the right hedge is a `mousedown` snapshot, which cannot go stale because a
+mousedown must occur inside the gesture.
+
+## Known limitations
 
 - **`HistoryManager` does read-modify-write with no serialisation** ([#68]), so two
-  lookups a few milliseconds apart can lose an entry. This is what let one regression
-  test pass against broken code.
-- **A linked word cannot be double-clicked with Alt** ([#69]). Chrome aborts the gesture after
-  the second `mousedown` on an `<a>` with Alt held — no second `click`, no `dblclick`,
-  with or without the suppression above. Verified by instrumenting the page. Looking a
-  linked word up has therefore never worked on the Alt path, and the fix above does not
-  change it.
+  lookups a few milliseconds apart can lose an entry.
+- **A linked word cannot be double-clicked with Alt** ([#69]). Chrome aborts the gesture
+  after the second `mousedown` on an `<a>` with Alt held — no second `click`, no
+  `dblclick`, with or without the suppression above. Looking a linked word up has
+  therefore never worked on the Alt path, and nothing here changes it.
 
-That second one is why the suppression is tested on the event (`defaultPrevented`)
+The second is why the default suppression is tested on the event (`defaultPrevented`)
 rather than on its consequence. The consequence differs by modifier and platform, and
 two of the three are not observable in the harness at all: Ctrl is not offered on a Mac,
 and Shift's own mousedown suppression masks it.
 
-## Consequences worth knowing
-
-- **The two mouse paths now mean different things.** Double-click asks "the word I am
-  pointing at" — position is the source of truth. Single click asks "what I selected"
-  — the selection is. That makes the double-click gesture immune to every selection
-  oddity, not just Shift's, including a stale selection left by a previous lookup.
-- **`wordAtPoint` moved from fallback to primary**, which put two latent bugs on the
-  hot path and so got them fixed: `\w` is ASCII-only and turned `björn` into `bjrn` in
-  a *Swedish* dictionary, and the `caretPositionFromPoint` branch read a
-  `CaretPosition` as if it were a `Range`.
-- **Matching is exclusive.** `Alt+Shift+click` used to open a card and no longer does.
-  With three modifiers to choose between, a permissive match would fire
-  `Ctrl+Shift+click` for a Ctrl reader *and* a Shift reader, and compound chords are
-  where browsers and pages put meanings of their own — Cmd+click opens a link in a new
-  tab, and AltGr on Windows is literally Ctrl+Alt.
-- **`preventDefault()` on a matched click** suppresses Alt+click-downloads-a-link and
-  Ctrl+click-opens-a-background-tab, and the Shift-only mousedown one additionally
-  costs focus-on-click and drag-start — all only while the trigger modifier is held,
-  so ordinary interaction is untouched.
-- **The `altKeyDown` keyboard tracker was deleted.** It existed as a "Mac
-  compatibility" fallback, and it was stale state by construction: `keyup` is never
-  delivered if the key is released while the document lacks focus, so one Alt+Tab left
-  it stuck `true` and *any* plain double-click opened a card. Generalising it to three
-  modifiers would have made Shift+Tab and Ctrl+Tab do the same. If a Mac regression
-  ever does appear, the correct hedge is a `mousedown` snapshot, which cannot go stale
-  because a mousedown must occur inside the gesture.
-- **This is the extension's only `chrome.storage.onChanged` listener**, and it watches
-  one key. Every other setting is re-read by the action that displays it, so staleness
-  heals itself after one card. The trigger cannot work that way: a reader changes it
-  precisely because their desktop intercepts the current one, so the page they were
-  reading has no way to open a card and re-read on its own. Waiting would look exactly
-  like the setting doing nothing. The cost is one listener per frame, firing on every
-  local-storage write; the body is a single key check.
-- **The shortcut is silent when nothing is selected.** Falling back to opening the
-  Action Popup was rejected: on `chrome://` pages, the Web Store and the PDF viewer no
-  frame ever answers, so the panel would fly open on every press. The Options page
-  shows the live binding (`chrome.commands.getAll`) instead, which also covers the
-  case where another extension already holds `Ctrl+Shift+L` and Chrome silently left
-  ours unassigned.
-- **`commands` is a manifest key, not a permission.** `permissions` is still exactly
-  `["storage", "offscreen"]` and the install warning is unchanged. `ManifestTests`
-  says so explicitly so nobody "fixes" the permission list to match.
-
 ## What the tests cannot prove
 
 Playwright drives Chrome over CDP, which injects input *below* the layer where Ash and
-Mutter take Alt + click. **The original bug is not reproducible in the test suite on
-any platform**, and no test will ever fail because of it. The suite proves the trigger
-is configurable, that a non-default modifier works where the default does not, that a
-change reaches an already-open tab, that dismissal still works, and that the copy
-tells the truth. Chrome's dispatch of a keystroke to `onCommand` is likewise not
-reachable — `page.keyboard.press` goes to the renderer — so the command tests drive
-the worker's handler directly and say so.
+Mutter take Alt + click. **The original bug is not reproducible in the test suite on any
+platform**, and no test will ever fail because of it. The suite proves the trigger is
+configurable, that a non-default modifier works where the default does not, that a
+change reaches an already-open tab, that dismissal still works, and that the copy tells
+the truth. Chrome's dispatch of a keystroke to `onCommand` is likewise not reachable —
+`page.keyboard.press` goes to the renderer — so the command tests drive the worker's
+handler directly and say so.
 
 The interception itself is verified by hand, on the platform.
 
 [#15]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/15
-[#68]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/68
-[#69]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/69
 [#17]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/17
 [#21]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/21
+[#68]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/68
+[#69]: https://github.com/SergVro/Lexin-dictionary-Chrome-Extension/issues/69

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -68,6 +68,7 @@ ways, and reasoning about the DOM finds none of them:
 | `bil<br>hund`, `bil<img>hund` | two words | `bilhund` — the gap carries no text |
 | `h<span hidden>ZZZ</span>und` | one word | `h`/`und` — `display:none` is not inline |
 | `bil<svg><title>ikon</title></svg>hund` | two words | `bilikonhund` — a name, not text |
+| text inside a shadow root | one word | nothing — the caret API stops at the host |
 
 So `wordAtPoint` reads the whole run of text a word sits in — walking the inline
 elements inside the nearest block — and decides what ends that run **geometrically**,
@@ -86,6 +87,22 @@ are wrong in opposite directions: with no rule at all an icon is elided and
 `h<span></span>und` breaks into `und`. Geometry also gets `<svg>`, `<canvas>`,
 `<video>`, form controls, custom elements and `::before` icons right without naming any
 of them, and leaves `<wbr>` alone.
+
+### Reaching text inside a web component
+
+Neither caret API descends into a shadow tree unasked: `caretRangeFromPoint` answers
+with `BODY` for a point over one. A site built out of web components keeps most of its
+text there, so naming a word by position has to reach in — `elementFromPoint` walks
+down the host chain to collect the open roots, and `caretPositionFromPoint` is told
+which ones to look inside.
+
+That option is newer than the Chrome floor (116), so its result is checked rather than
+trusted: an older Chrome ignores the dictionary member and answers with the host, which
+names no word and falls through to the existing routes.
+
+A **closed** root stays out of reach — nothing can enumerate one from outside. The
+reader's own selection pierces even those, which is what the double-click path falls
+back on where a selection exists.
 
 Moving `wordAtPoint` from fallback to primary put two latent bugs on the hot path and
 so got them fixed: `\w` is ASCII-only and turned `björn` into `bjrn` in a *Swedish*

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -141,6 +141,17 @@ correction is wrong in the other one: with no rule the icon is elided and the lo
 reads `bilhund`; with the naive "every textless element separates" rule,
 `h<span></span>und` breaks into `und`.
 
+A fifth round found the mirror of it: a *hidden* element renders no box, and
+`display: none` fails every test for flowing inline, so `h<span hidden></span>und` was
+read as a block boundary and cut the visible word in half. Nothing rendered is now
+skipped outright - contributing neither text nor a boundary - which also keeps the
+source of a `<script>` left mid-sentence out of the flowed text.
+
+The pattern across those two rounds is worth naming: **this walk has to agree with
+what the reader sees, and every disagreement shows up as a lookup for a word that is
+not on the page.** Text present but invisible, and space taken but textless, are the
+two ways markup and rendering come apart, and each needed its own rule.
+
 ## Pre-existing limitations this work uncovered but did not fix
 
 - **`HistoryManager` does read-modify-write with no serialisation**, so two lookups a

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -147,10 +147,23 @@ read as a block boundary and cut the visible word in half. Nothing rendered is n
 skipped outright - contributing neither text nor a boundary - which also keeps the
 source of a `<script>` left mid-sentence out of the flowed text.
 
-The pattern across those two rounds is worth naming: **this walk has to agree with
-what the reader sees, and every disagreement shows up as a lookup for a word that is
-not on the page.** Text present but invisible, and space taken but textless, are the
-two ways markup and rendering come apart, and each needed its own rule.
+A sixth round found the third variant: an accessible `<svg><title>ikon</title></svg>`
+icon *has* text, so the textless test let it through and the walk read the page as
+`bilikonhund`. A `<title>` is a name for screen readers, and a `<canvas>`'s fallback
+is the same; both appear in `textContent` and both measure zero.
+
+The pattern across those three rounds is worth naming, because it was the thing I kept
+missing rather than three separate oversights: **this walk has to agree with what the
+reader sees, and every disagreement shows up as a lookup for a word that is not on the
+page.** Markup and rendering come apart in three ways - text present but invisible,
+space taken but textless, and text present but not drawn - and reasoning about the DOM
+finds none of them.
+
+So both halves of the question are asked geometrically: *does it take up room*
+(`getBoundingClientRect().width`) and *is any of its text drawn* (a `Range` around each
+text node, stopping at the first that measures). No list of tag names appears anywhere,
+which is what makes it right for `<svg>`, `<canvas>`, `<video>`, form controls, custom
+elements and `::before` icons alike - none of which are named.
 
 ## Pre-existing limitations this work uncovered but did not fix
 

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -82,13 +82,44 @@ Three defects Codex found on the PR, all of them real:
   Fixed by ignoring clicks carrying `detail > 1`.
   - Under Shift there is a second half: suppressing the mousedown default keeps an
     older selection alive, so the *first* click of a double-click would look *that*
-    up. Fixed by deferring the click lookup and cancelling it when a double-click
-    follows. Only the Shift path waits, so the shipped trigger costs nothing.
+    up. The click path now requires the click to have landed **on** the selection.
 
-Each has a regression test, and each test was verified by removing its fix and
-watching it fail. That mattered: two of them passed at first against the broken code,
-because a lookup's card is dismissed by the next one and leaves no trace on the page.
-Both now count history entries instead, which is where the harm actually lands.
+A second round found three more:
+
+- **Split words were still broken under Shift**, whose selection is suppressed and so
+  had no browser selection to defer to. `wordAtPoint` now reads the whole run of text
+  a word sits in — walking the inline elements inside the nearest block — so
+  `h<em>u</em>nd` is one word to it too. This matters more than it first appears:
+  pages split words whenever they emphasise, link or highlight part of one, which
+  search results do to almost every word they show.
+- **A deferred lookup outlived its dismissal.** The first fix for the stale-selection
+  case waited out a grace period before looking up; Escape or a click elsewhere during
+  that window removed the card but left the timer running, so it reopened.
+- **The grace period was guesswork.** It assumed a 500ms double-click interval, but
+  the interval is configured by the reader and Chrome does not expose it — Windows
+  allows up to 5 seconds.
+
+The last two dissolved rather than being patched. **Where the click landed** answers
+the same question with no interval in it at all: a reader looking their selection up
+clicks *on* it, and a reader starting a double-click elsewhere does not. That is known
+at once, so the timer, the grace constant and the pending-lookup state all went away,
+and the select-then-click flow stopped costing a wait.
+
+Each finding has a regression test, and each test was verified by removing its fix and
+watching it fail. That mattered more than expected — **three tests passed against the
+broken code on the first attempt**:
+
+- two counted cards, but a lookup dismisses the previous card before opening its own,
+  so a duplicate leaves exactly one card behind and is invisible from the page. They
+  count history entries now.
+- one counted history entries for a *double-click*, where two lookups fire close
+  enough together to read the same store and overwrite one another. It asserts only
+  the final card now; the mechanism it was meant to pin is covered by a single-click
+  test instead, where a wrong lookup has nothing to hide behind.
+
+That last one is worth stating plainly as a **pre-existing limitation this work
+uncovered but did not fix**: `HistoryManager` does read-modify-write with no
+serialisation, so two lookups a few milliseconds apart can lose an entry.
 
 ## Consequences worth knowing
 

--- a/docs/adr/0005-configurable-lookup-trigger.md
+++ b/docs/adr/0005-configurable-lookup-trigger.md
@@ -128,6 +128,19 @@ A third round found two more:
   so flowing the surrounding text together read `bil<br>hund` as `bilhund` and looked
   *that* up. Line breaks and nested blocks now contribute a newline instead of nothing.
 
+A fourth round found the same class of bug once more, in the elements that carry no
+text but do take up room: an icon between two words left `bil<img>hund` reading as one.
+
+The rule is **"does it take up room"** — `getBoundingClientRect().width > 0` on a
+textless inline element — rather than a list of tag names. That is the question the
+reader's eye is answering, and asking it directly gets `<img>`, `<svg>`, form controls
+and custom elements right without naming any of them, leaves `<wbr>` and zero-width
+wrappers alone, and catches an icon drawn by a `::before` rule whose glyph never
+appears in `textContent` at all. Its test pins both directions, because the obvious
+correction is wrong in the other one: with no rule the icon is elided and the lookup
+reads `bilhund`; with the naive "every textless element separates" rule,
+`h<span></span>und` breaks into `und`.
+
 ## Pre-existing limitations this work uncovered but did not fix
 
 - **`HistoryManager` does read-modify-write with no serialisation**, so two lookups a

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -41,8 +41,13 @@ HOW TO LOOK A WORD UP
 
 • Alt + double-click a word on the page
 • Or select the text, then Alt + click it
+• Or press the keyboard shortcut on a word you've selected — no mouse needed
 • Or click the toolbar icon and type the word — you can also swap the direction and
   translate from your language into Swedish
+
+Prefer a different key? Alt, Ctrl and Shift are all offered in Options. That matters
+on ChromeOS and some Linux desktops, which keep Alt for themselves and never pass it
+on to the page.
 
 Translations include Lexin's pronunciation audio where the dictionary provides it,
 and the card works inside iframes, so Gmail and similar apps are covered too.
@@ -86,7 +91,7 @@ PRIVACY
 • The only thing that leaves your browser is the word you look up, sent over HTTPS
   to the dictionary.
 • Chrome warns that this extension can "read and change your data on websites you
-  visit". That is what lets it see the word you Alt+click on the page in front of
+  visit". That is what lets it see the word you look up on the page in front of
   you. It reads nothing else, and keeps no record of the pages you visit.
 
 

--- a/src/html/help.html
+++ b/src/html/help.html
@@ -23,13 +23,16 @@
             <li class="lxStep">
                 <span class="lxStepNumber">01</span>
                 <span class="lxStepIcon" data-icon="keyboard"></span>
-                <span class="lxStepTitle">Alt + double-click a word</span>
+                <!-- The gesture is the reader's to choose in Options, so these two
+                     titles are rewritten on load. They ship naming Alt, which is the
+                     default and what most readers will see. -->
+                <span class="lxStepTitle" id="stepDoubleClick">Alt + double-click a word</span>
                 <span class="lxStepDetail">On any Swedish page.</span>
             </li>
             <li class="lxStep">
                 <span class="lxStepNumber">02</span>
                 <span class="lxStepIcon" data-icon="pointer"></span>
-                <span class="lxStepTitle">Select, then Alt + click</span>
+                <span class="lxStepTitle" id="stepClick">Select, then Alt + click</span>
                 <span class="lxStepDetail">If you'd rather select first.</span>
             </li>
             <li class="lxStep">
@@ -57,7 +60,14 @@
         <p class="lxProse">
             <a class="lxLink" href="options.html">Options</a> is where you choose which languages appear
             in the picker, which one a lookup uses by default, whether the extension follows your
-            system's light or dark appearance, and whether lookups are recorded at all.
+            system's light or dark appearance, whether lookups are recorded at all, and which key you
+            hold to look a word up.
+        </p>
+        <p class="lxProse">
+            That last one matters on ChromeOS and some Linux desktops, which keep Alt for themselves
+            and never pass it on to the page. Switch to another key there — or set a keyboard shortcut,
+            also from Options, which translates the selected word and is the one trigger no desktop
+            can intercept.
         </p>
 
         <hr class="lxHr" />

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -66,6 +66,26 @@
                 <span class="lxHint">Off stops new lookups being stored. Words already in your
                     history stay until you clear them there.</span>
             </div>
+            <div class="lxField">
+                <label id="triggerModifierLabel">Translate with</label>
+                <div class="lxSeg" role="radiogroup" aria-labelledby="triggerModifierLabel" id="triggerModifier">
+                    <label class="lxSegOption"><input type="radio" name="triggerModifier" value="alt" /><span>Alt</span></label>
+                    <label class="lxSegOption"><input type="radio" name="triggerModifier" value="ctrl" /><span>Ctrl</span></label>
+                    <label class="lxSegOption"><input type="radio" name="triggerModifier" value="shift" /><span>Shift</span></label>
+                </div>
+                <span class="lxHint">Held while you click or double-click a word. ChromeOS and
+                    some Linux desktops keep Alt for themselves, which is what this is here for.
+                    Shift also extends a selection you already have.</span>
+            </div>
+            <div class="lxField">
+                <label id="shortcutLabel">Keyboard shortcut</label>
+                <button type="button" id="openShortcuts" class="lxButton lxButtonQuiet"
+                        aria-describedby="shortcutHint">Set a keyboard shortcut…</button>
+                <span class="lxHint" id="shortcutHint">Translates whatever is selected, with no
+                    mouse at all. Chrome owns the binding: this opens
+                    chrome://extensions/shortcuts, where <b>Translate the selected word</b> can be
+                    bound to any combination.</span>
+            </div>
         </div>
     </main>
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,6 +23,15 @@
     "storage",
     "offscreen"
   ],
+  "commands": {
+    "translate-selection": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+L",
+        "mac": "Command+Shift+L"
+      },
+      "description": "Translate the selected word"
+    }
+  },
   "content_scripts": [
     {
       "run_at": "document_end",

--- a/src/scripts/common/Interfaces.ts
+++ b/src/scripts/common/Interfaces.ts
@@ -59,6 +59,10 @@ export interface IMessageService {
     createNewTab(url: string): void;
     openActionPopup(): Promise<void>;
     playAudio(url: string): Promise<void>;
+    /** Asks the active tab to look up whatever it has selected. */
+    translateSelection(): Promise<void>;
+    /** What Chrome has the named command bound to, or "" when it is unassigned. */
+    getCommandShortcut(command: string): Promise<string>;
 }
 
 /** Plays a pronunciation clip. See OffscreenAudioPlayer for the only implementation. */
@@ -95,6 +99,9 @@ export interface IMessageBus {
     sendMessage(method: MessageType, args?: any): Promise<any>;
     sendMessageToActiveTab(method: MessageType, args?: any): Promise<any>;
     createNewTab(url: string): void;
+    /** Runs `handler` when Chrome reports the named keyboard shortcut was pressed. */
+    registerCommandHandler(command: string, handler: () => void): void;
+    getCommandShortcut(command: string): Promise<string>;
 }
 
 export interface GetTranslationHandler {
@@ -129,6 +136,17 @@ export interface PlayAudioHandler {
     (url: string): Promise<any>;
 }
 
+/**
+ * Answers the keyboard shortcut in one frame of the tab.
+ *
+ * Returns true where it acted and nothing at all where it did not - every frame is
+ * asked, and only the one holding the reader's selection should reply. See
+ * registerGetSelectionHandler, which stays silent for the same reason.
+ */
+export interface TranslateSelectionHandler {
+    (): boolean | void;
+}
+
 export interface IMessageHandlers {
     registerGetTranslationHandler(handler: GetTranslationHandler): void ;
     registerLoadHistoryHandler(handler: LoadHistoryHandler): void;
@@ -139,6 +157,7 @@ export interface IMessageHandlers {
     registerOpenActionPopupHandler(handler: OpenActionPopupHandler): void;
     registerPlayAudioHandler(handler: PlayAudioHandler): void;
     registerPlayAudioInOffscreenDocumentHandler(handler: PlayAudioHandler): void;
+    registerTranslateSelectionHandler(handler: TranslateSelectionHandler): void;
 }
 
 

--- a/src/scripts/common/LookupTrigger.ts
+++ b/src/scripts/common/LookupTrigger.ts
@@ -1,0 +1,127 @@
+/**
+ * The gesture that opens a Translation Card on a page.
+ *
+ * Alt was the only trigger for the extension's whole life, and on most desktops it is
+ * a fine one. ChromeOS is not most desktops: there Alt+click *is* the secondary click,
+ * consumed by the window server before the page is sent anything at all. GNOME grabs
+ * it for window-move. Readers on those desktops could not look a word up, and no
+ * amount of care in a content script wins an event it never receives - so the
+ * modifier became theirs to choose.
+ *
+ * The rules live here rather than on Settings because none of them need storage:
+ * every one takes what it needs as an argument, which is also what makes them
+ * testable under node with no browser at all.
+ */
+
+/**
+ * The keyboard shortcut declared in the manifest, and the other half of the answer:
+ * a shortcut is the one trigger no desktop can take for itself. Chrome routes it to
+ * the service worker and nowhere else, and owns the binding at
+ * chrome://extensions/shortcuts.
+ */
+export const TRANSLATE_SELECTION_COMMAND = "translate-selection";
+
+/** The key a reader holds while clicking a word. Single modifiers only. */
+export type TriggerModifier = "alt" | "ctrl" | "shift";
+
+export const DEFAULT_TRIGGER: TriggerModifier = "alt";
+
+/** Every modifier the setting can hold, in the order the Options page offers them. */
+export const TRIGGER_MODIFIERS: TriggerModifier[] = ["alt", "ctrl", "shift"];
+
+/**
+ * The shape matchesTrigger reads. A MouseEvent satisfies it in production; a unit test
+ * satisfies it with an object literal, which is the point - the predicate is the one
+ * piece of this feature worth testing exhaustively, and it should not need a DOM.
+ */
+export interface IModifierState {
+    altKey?: boolean;
+    ctrlKey?: boolean;
+    shiftKey?: boolean;
+    metaKey?: boolean;
+    getModifierState?(key: string): boolean;
+}
+
+/** The DOM's name for each modifier, for getModifierState. */
+const MODIFIER_STATE_KEYS: { [key: string]: string } = {
+    alt: "Alt",
+    ctrl: "Control",
+    shift: "Shift",
+    meta: "Meta"
+};
+
+/** Whether this platform is a Mac. Injectable everywhere below so tests need no stub. */
+export function onMac(): boolean {
+    if (typeof navigator === "undefined") {
+        return false;
+    }
+    const platform = (navigator as Navigator & { userAgentData?: { platform?: string } })
+        .userAgentData?.platform || navigator.platform || "";
+    return /mac/i.test(platform);
+}
+
+/** Whether a single modifier is down, by either the flag or the standard API. */
+function held(event: IModifierState, modifier: string): boolean {
+    const flag = event[(modifier + "Key") as keyof IModifierState];
+    if (flag === true) {
+        return true;
+    }
+    // getModifierState is the documented API; the flat flags are the legacy one. Both
+    // are read because either can be the one a given event carries.
+    const stateKey = MODIFIER_STATE_KEYS[modifier];
+    return !!(stateKey && typeof event.getModifierState === "function"
+        && event.getModifierState(stateKey));
+}
+
+/**
+ * Whether this event carries the reader's modifier and nothing else.
+ *
+ * The match is exclusive, which is a change from the Alt-only behaviour: Alt+Shift+click
+ * used to open a card and no longer does. With three modifiers to choose between,
+ * a permissive match would fire Ctrl+Shift+click for a Ctrl reader *and* a Shift one,
+ * and compound chords are exactly where browsers and pages put meanings of their own -
+ * Cmd+click opens a link in a new tab, and AltGr on Windows is literally Ctrl+Alt.
+ */
+export function matchesTrigger(event: IModifierState, modifier: TriggerModifier): boolean {
+    if (!held(event, modifier)) {
+        return false;
+    }
+    const others = TRIGGER_MODIFIERS.filter((other) => other !== modifier);
+    return !others.some((other) => held(event, other)) && !held(event, "meta");
+}
+
+/** Whether this is a modifier we understand. Used by the validate-or-default read. */
+export function isTriggerModifier(value: string | null): value is TriggerModifier {
+    return value !== null && (TRIGGER_MODIFIERS as string[]).indexOf(value) !== -1;
+}
+
+/**
+ * The modifiers this platform can actually deliver.
+ *
+ * Ctrl is not offered on a Mac, and that is deliberate rather than an oversight: macOS
+ * defines Ctrl+click as the secondary click, so Chrome raises contextmenu off the
+ * mousedown and never fires the click at all. The gesture cannot work there whatever
+ * the page does. A Mac needs no escape hatch anyway - Option+click, the default, is
+ * precisely what this feature exists to work around on other desktops.
+ */
+export function availableModifiers(mac: boolean = onMac()): TriggerModifier[] {
+    return TRIGGER_MODIFIERS.filter((modifier) => !(mac && modifier === "ctrl"));
+}
+
+/** What to call the key in prose. A Mac engraves Alt as Option and Ctrl as Control. */
+export function modifierLabel(modifier: TriggerModifier, mac: boolean = onMac()): string {
+    if (mac) {
+        if (modifier === "alt") { return "Option"; }
+        if (modifier === "ctrl") { return "Control"; }
+    }
+    if (modifier === "alt") { return "Alt"; }
+    if (modifier === "ctrl") { return "Ctrl"; }
+    return "Shift";
+}
+
+/** The whole gesture, as the help page and the empty states say it. */
+export function gestureLabel(modifier: TriggerModifier,
+                             gesture: "click" | "double-click",
+                             mac: boolean = onMac()): string {
+    return modifierLabel(modifier, mac) + " + " + gesture;
+}

--- a/src/scripts/common/Settings.ts
+++ b/src/scripts/common/Settings.ts
@@ -1,6 +1,10 @@
 import { IAsyncSettingsStorage } from "./Interfaces.js";
+import { availableModifiers, DEFAULT_TRIGGER, onMac, TriggerModifier } from "./LookupTrigger.js";
 
 const RECORD_HISTORY_KEY = "recordHistory";
+
+/** Exported: the content script watches this key to pick a change up without a reload. */
+export const TRIGGER_MODIFIER_KEY = "triggerModifier";
 
 /**
  * The extension's plain stored preferences.
@@ -12,9 +16,16 @@ const RECORD_HISTORY_KEY = "recordHistory";
 class Settings {
 
     private settingsStorage: IAsyncSettingsStorage;
+    private onMac: () => boolean;
 
-    constructor(settingsStorage: IAsyncSettingsStorage) {
+    /**
+     * @param onMac overridable for the same reason ThemeManager takes prefersDark:
+     *              one setting resolves against the platform, and a test that has to
+     *              run on both a Mac and a Linux CI box cannot ask the real one.
+     */
+    constructor(settingsStorage: IAsyncSettingsStorage, onMacPlatform?: () => boolean) {
         this.settingsStorage = settingsStorage;
+        this.onMac = onMacPlatform || onMac;
     }
 
     /**
@@ -34,6 +45,32 @@ class Settings {
 
     async setRecordHistory(value: boolean): Promise<void> {
         await this.settingsStorage.setItem(RECORD_HISTORY_KEY, value ? "true" : "false");
+    }
+
+    /**
+     * The modifier a reader holds to look a word up on the page.
+     *
+     * Defaults to Alt, which is what every existing reader has been using and what most
+     * desktops leave alone. The setting exists for the ones that do not - see
+     * LookupTrigger.
+     *
+     * Validated against what this platform can deliver rather than against the full
+     * list: a modifier that cannot fire here would leave the reader with no working
+     * gesture at all, and falling back to Alt at least leaves them one.
+     */
+    async getTriggerModifier(): Promise<TriggerModifier> {
+        const stored = await this.settingsStorage.getItem(TRIGGER_MODIFIER_KEY);
+        const usable = availableModifiers(this.onMac());
+        if (stored !== null && (usable as string[]).indexOf(stored) !== -1) {
+            return stored as TriggerModifier;
+        }
+        // Unset, unusable on this platform, or a value written by a newer version we
+        // do not understand.
+        return DEFAULT_TRIGGER;
+    }
+
+    async setTriggerModifier(value: TriggerModifier): Promise<void> {
+        await this.settingsStorage.setItem(TRIGGER_MODIFIER_KEY, value);
     }
 }
 

--- a/src/scripts/content/ContentScript.ts
+++ b/src/scripts/content/ContentScript.ts
@@ -1,11 +1,14 @@
 import { IMessageService, IMessageHandlers } from "../common/Interfaces.js";
 import * as DomUtils from "../util/DomUtils.js";
-import { position } from "../util/PositionUtils.js";
+import { position, PositionOptions } from "../util/PositionUtils.js";
 import { processTranslationHtml } from "../util/TranslationUtils.js";
 import * as Icons from "../util/Icons.js";
 import * as States from "../util/States.js";
 import ThemeManager, { applyTheme, Theme } from "../common/ThemeManager.js";
 import LanguageLabel, { ILanguageLabel } from "../common/LanguageLabel.js";
+import Settings from "../common/Settings.js";
+import { DEFAULT_TRIGGER, matchesTrigger, TriggerModifier } from "../common/LookupTrigger.js";
+import { wordAtPoint } from "./WordAtPoint.js";
 import tokensCss from "../../css/tokens.css";
 import componentsCss from "../../css/components.css";
 import cardCss from "../../css/card.css";
@@ -36,12 +39,16 @@ function getCardStyleSheet(): CSSStyleSheet {
 
 const HOST_CLASS = "lexinExtensionMainContainer";
 
+/** Where a card points: the click that opened it, or the selection a command found. */
+type CardAnchor = Pick<PositionOptions, "of" | "fixed">;
+
 class ContentScript {
 
     messageService: IMessageService;
     private messageHandlers: IMessageHandlers;
     private themeManager: ThemeManager;
     private languageLabel: LanguageLabel;
+    private settings: Settings;
 
     /**
      * What the card should say about itself, cached so a card can be built
@@ -51,15 +58,27 @@ class ContentScript {
     private theme: Theme = "light";
     private label: ILanguageLabel = { code: "sv", name: "Swedish" };
 
+    /**
+     * The modifier that opens a card, cached for the same reason as the two above:
+     * the click handler has to decide synchronously, and awaiting storage inside it
+     * would mean deciding after the click had already gone by.
+     *
+     * Alt until the first read lands, which is what a reader who never opened the
+     * Options page has anyway.
+     */
+    private trigger: TriggerModifier = DEFAULT_TRIGGER;
+
     private zIndex = 10000;
     private clickedInsideCard = false;
 
     constructor(MessageService: IMessageService, messageHandlers: IMessageHandlers,
-                themeManager: ThemeManager, languageLabel: LanguageLabel) {
+                themeManager: ThemeManager, languageLabel: LanguageLabel,
+                settings: Settings) {
         this.messageService = MessageService;
         this.messageHandlers = messageHandlers;
         this.themeManager = themeManager;
         this.languageLabel = languageLabel;
+        this.settings = settings;
     }
 
     getSelection(): string {
@@ -80,6 +99,55 @@ class ContentScript {
         });
     }
 
+    /**
+     * Opens a card on the selection when the reader presses the keyboard shortcut.
+     *
+     * Every frame in the tab is asked, because the worker cannot know which one the
+     * reader is in, and exactly one should answer. hasFocus alone would not name it -
+     * a top document reports true while focus sits inside one of its iframes - and a
+     * selection alone would not either, since a frame keeps its selection after focus
+     * has moved on. Together they leave one frame: of the focused ancestor chain, at
+     * most one holds a live selection.
+     */
+    handleTranslateSelection(): void {
+        this.messageHandlers.registerTranslateSelectionHandler(() => {
+            if (!document.hasFocus()) {
+                return;
+            }
+            const selection = this.getSelection();
+            if (!selection) {
+                return;
+            }
+            this.removeCard();
+            this.showTranslation(selection, this.selectionAnchor());
+            return true;
+        });
+    }
+
+    /**
+     * Where a keyboard-summoned card points: the selection itself.
+     *
+     * A Range's rect is in viewport coordinates, so `fixed` is set explicitly - the
+     * mouse paths get that for free by passing a MouseEvent, and this one would
+     * otherwise be read as document coordinates and land wrong on a scrolled page.
+     * Reducing the rect to its top centre puts the card exactly where a click in the
+     * middle of the word would have put it, so the alignment strings mean the same
+     * thing on both paths.
+     */
+    private selectionAnchor(): CardAnchor {
+        const selection = window.getSelection();
+        const rect = selection && selection.rangeCount > 0
+            ? selection.getRangeAt(0).getBoundingClientRect()
+            : undefined;
+
+        if (!rect || (rect.width === 0 && rect.height === 0)) {
+            // A selection with no geometry, inside a collapsed or hidden node. The
+            // card still has to land somewhere the reader will look.
+            return { of: { left: window.innerWidth / 2, top: window.innerHeight / 3 }, fixed: true };
+        }
+        return { of: { left: rect.left + rect.width / 2, top: rect.top }, fixed: true };
+    }
+
     /** Dismisses the open card, whether by the close button, Escape, or a click out. */
     private removeCard(): void {
         const host = document.querySelector("." + HOST_CLASS) as HTMLElement;
@@ -92,6 +160,16 @@ class ContentScript {
     private async refreshCardContext(): Promise<void> {
         this.theme = await this.themeManager.getTheme();
         this.label = await this.languageLabel.getCurrent();
+        await this.refreshTrigger();
+    }
+
+    /**
+     * Re-reads the trigger. Public because content.ts calls it from a storage
+     * subscription: this is the one setting a page cannot afford to pick up lazily,
+     * since the reader changes it precisely when no card can be opened to refresh it.
+     */
+    async refreshTrigger(): Promise<void> {
+        this.trigger = await this.settings.getTriggerModifier();
     }
 
     /**
@@ -162,7 +240,7 @@ class ContentScript {
         DomUtils.setAttr(pair, "aria-label", this.label.name);
     }
 
-    private showTranslation(selection: string, evt: MouseEvent): void {
+    private showTranslation(selection: string, anchor: CardAnchor): void {
         const self = this;
         const absoluteContainer = DomUtils.createElement("div");
         DomUtils.addClass(absoluteContainer, HOST_CLASS);
@@ -213,7 +291,7 @@ class ContentScript {
         // Function to position the container
         const positionContainer = () => {
             position(container, {
-                of: evt,
+                ...anchor,
                 my: "center+10 bottom-20",
                 at: "center top",
                 collision: "flipfit"
@@ -247,83 +325,87 @@ class ContentScript {
         });
     }
 
+    /**
+     * Closes the open card unless the click landed inside it.
+     *
+     * The card lives in an open shadow root, so its own clicks still bubble out to
+     * document - the flag set on the card container in showTranslation is how the two
+     * are told apart. Nothing here knows or cares what the trigger is, which is the
+     * point: the click listener does double duty, and dismissal has to keep working
+     * whatever modifier the reader picked.
+     */
+    private dismissOnClickOut(): void {
+        if (!this.clickedInsideCard) {
+            this.removeCard();
+        }
+        this.clickedInsideCard = false;
+    }
+
     subscribeOnClicks() {
-        const self = this;
-
-        // Handle single click with Alt key
-        document.addEventListener("click", function (evt: MouseEvent) {
-            if (!self.clickedInsideCard) {
-                self.removeCard();
-            }
-            self.clickedInsideCard = false;
-            const selection = self.getSelection();
-            // On Mac, check both altKey and the Option key using getModifierState
-            const isAltPressed = evt.altKey || (evt.getModifierState && evt.getModifierState("Alt"));
-            if (selection && isAltPressed) {
-                self.showTranslation(selection, evt);
-            }
-        });
-
-        // Handle double click with Alt key (for Mac compatibility)
-        // Note: On Mac, we need to check modifier state differently
-        // Also listen on mousedown to catch Alt key state before double-click
-        let altKeyDown = false;
-        document.addEventListener("keydown", function (e: KeyboardEvent) {
-            if (e.key === "Alt" || e.key === "Option" || e.altKey) {
-                altKeyDown = true;
-            }
-        });
-        document.addEventListener("keyup", function (e: KeyboardEvent) {
-            if (e.key === "Alt" || e.key === "Option" || !e.altKey) {
-                altKeyDown = false;
-            }
-        });
-
-        document.addEventListener("dblclick", function (evt: MouseEvent) {
-            // On Mac, check both altKey and the Option key using getModifierState
-            // Also check our tracked altKeyDown state as fallback
-            const isAltPressed = evt.altKey ||
-                                (evt.getModifierState && evt.getModifierState("Alt")) ||
-                                altKeyDown;
-
-            if (isAltPressed) {
-                // Prevent default double-click behavior (like text selection)
+        // Stop Shift dragging the selection along behind it.
+        //
+        // Selection changes happen on mousedown, and Shift+click's whole meaning is
+        // "extend the selection from the existing anchor" - so after one lookup the
+        // anchor sits on the first word, and the next Shift+click selects everything
+        // in between, highlighted across the page. Preventing the default stops that
+        // at the source.
+        //
+        // Only for Shift, deliberately. Alt and Ctrl replace the selection rather than
+        // extending it, so they have nothing to fix - and suppressing the default for
+        // them would throw away the browser's own double-click word selection, which
+        // the dblclick handler below still wants as a fallback for when
+        // caretRangeFromPoint cannot answer. Leaving the default alone for the
+        // shipped trigger also means Alt behaves exactly as it always has.
+        //
+        // The cost, for Shift only: a trigger-click no longer focuses what it lands
+        // on and cannot start a drag.
+        document.addEventListener("mousedown", (evt: MouseEvent) => {
+            if (this.trigger === "shift" && matchesTrigger(evt, this.trigger)) {
                 evt.preventDefault();
-                evt.stopPropagation();
-
-                // Get the word at the double-click position
-                // First try to get selection (browser may have selected the word)
-                let selection = self.getSelection();
-
-                // If no selection, try to get word from the click position
-                if (!selection || selection.trim() === "") {
-                    const range = document.caretRangeFromPoint?.(evt.clientX, evt.clientY) ||
-                                  (document as any).caretPositionFromPoint?.(evt.clientX, evt.clientY);
-                    if (range) {
-                        const textNode = range.startContainer;
-                        if (textNode.nodeType === Node.TEXT_NODE) {
-                            const text = textNode.textContent || "";
-                            const offset = range.startOffset;
-                            // Extract word at cursor position - look for word boundaries
-                            const beforeText = text.substring(Math.max(0, offset - 100), offset);
-                            const afterText = text.substring(offset, Math.min(text.length, offset + 100));
-                            const beforeMatch = beforeText.match(/(\w+)$/);
-                            const afterMatch = afterText.match(/^(\w+)/);
-                            if (beforeMatch || afterMatch) {
-                                selection = (beforeMatch ? beforeMatch[1] : "") + (afterMatch ? afterMatch[1] : "");
-                            }
-                        }
-                    }
-                }
-
-                if (selection && selection.trim() !== "") {
-                    if (!self.clickedInsideCard) {
-                        self.removeCard();
-                    }
-                    self.clickedInsideCard = false;
-                    self.showTranslation(selection.trim(), evt);
-                }
             }
+        });
+
+        document.addEventListener("click", (evt: MouseEvent) => {
+            // Unconditionally, and before anything else: every click outside an open
+            // card closes it, trigger or not.
+            this.dismissOnClickOut();
+
+            if (!matchesTrigger(evt, this.trigger)) {
+                return;
+            }
+            // "Translate what I selected." The selection is the source of truth on
+            // this path, and the mousedown handler above is what kept it intact long
+            // enough to read.
+            const selection = this.getSelection();
+            if (!selection) {
+                return;
+            }
+            // The gesture is ours now, so do not also let the page have it: Alt+click
+            // downloads a link and Ctrl+click opens a background tab, on a word the
+            // reader only meant to look up.
+            evt.preventDefault();
+            this.showTranslation(selection, { of: evt });
+        });
+
+        document.addEventListener("dblclick", (evt: MouseEvent) => {
+            if (!matchesTrigger(evt, this.trigger)) {
+                return;
+            }
+            evt.preventDefault();
+            evt.stopPropagation();
+
+            // "Translate the word I am pointing at." Position is the source of truth
+            // here, not the selection: the mousedown handler means the browser never
+            // selected the word for us, and reading the selection instead would hand
+            // back whatever was left over from the last lookup. getSelection is the
+            // fallback only for the case where a page's own scripting put a live
+            // selection under the pointer.
+            const selection = wordAtPoint(evt.clientX, evt.clientY) || this.getSelection();
+            if (!selection) {
+                return;
+            }
+            this.dismissOnClickOut();
+            this.showTranslation(DomUtils.trim(selection), { of: evt });
         });
     }
 
@@ -344,6 +426,7 @@ class ContentScript {
 
     initialize() {
         this.handleGetSelection();
+        this.handleTranslateSelection();
         this.subscribeOnClicks();
         this.subscribeOnKeyboard();
         // Warm the cache so the first card of the session is themed and labelled

--- a/src/scripts/content/ContentScript.ts
+++ b/src/scripts/content/ContentScript.ts
@@ -39,6 +39,16 @@ function getCardStyleSheet(): CSSStyleSheet {
 
 const HOST_CLASS = "lexinExtensionMainContainer";
 
+/**
+ * How long a click waits to find out whether it was the first half of a double-click.
+ *
+ * Above the double-click interval every desktop ships - 500ms on Windows and on
+ * macOS at the slider's slowest - so a reader whose double-click is deliberate still
+ * gets one card rather than two. Only ever waited on the Shift path, so the shipped
+ * trigger costs nothing.
+ */
+const DOUBLE_CLICK_GRACE_MS = 550;
+
 /** Where a card points: the click that opened it, or the selection a command found. */
 type CardAnchor = Pick<PositionOptions, "of" | "fixed">;
 
@@ -70,6 +80,9 @@ class ContentScript {
 
     private zIndex = 10000;
     private clickedInsideCard = false;
+
+    /** A click's lookup, still waiting to see whether a double-click follows it. */
+    private pendingLookup: number | undefined;
 
     constructor(MessageService: IMessageService, messageHandlers: IMessageHandlers,
                 themeManager: ThemeManager, languageLabel: LanguageLabel,
@@ -106,12 +119,19 @@ class ContentScript {
      * reader is in, and exactly one should answer. hasFocus alone would not name it -
      * a top document reports true while focus sits inside one of its iframes - and a
      * selection alone would not either, since a frame keeps its selection after focus
-     * has moved on. Together they leave one frame: of the focused ancestor chain, at
-     * most one holds a live selection.
+     * has moved on.
+     *
+     * Nor are the two together enough. Every document on the focused chain reports
+     * hasFocus, and each keeps whatever it had selected last - so a reader who
+     * selected a word in the page and then another inside an iframe leaves two
+     * documents claiming a live selection, and both would open a card and file a
+     * history entry. What names a single frame is being the *deepest* focused one:
+     * a document whose own activeElement is a frame has handed focus on, and the
+     * frame it handed it to is the one that should answer.
      */
     handleTranslateSelection(): void {
         this.messageHandlers.registerTranslateSelectionHandler(() => {
-            if (!document.hasFocus()) {
+            if (!document.hasFocus() || this.focusIsInAChildFrame()) {
                 return;
             }
             const selection = this.getSelection();
@@ -122,6 +142,17 @@ class ContentScript {
             this.showTranslation(selection, this.selectionAnchor());
             return true;
         });
+    }
+
+    /**
+     * Whether this document has passed focus down to a frame inside it.
+     *
+     * `activeElement` is the frame element itself in that case, which is how a
+     * document tells "I am focused" from "something inside me is".
+     */
+    private focusIsInAChildFrame(): boolean {
+        const active = document.activeElement;
+        return !!active && (active.tagName === "IFRAME" || active.tagName === "FRAME");
     }
 
     /**
@@ -360,7 +391,7 @@ class ContentScript {
         // The cost, for Shift only: a trigger-click no longer focuses what it lands
         // on and cannot start a drag.
         document.addEventListener("mousedown", (evt: MouseEvent) => {
-            if (this.trigger === "shift" && matchesTrigger(evt, this.trigger)) {
+            if (this.selectionIsOurs() && matchesTrigger(evt, this.trigger)) {
                 evt.preventDefault();
             }
         });
@@ -373,9 +404,15 @@ class ContentScript {
             if (!matchesTrigger(evt, this.trigger)) {
                 return;
             }
+            // A double-click arrives as click, click, dblclick. The second click
+            // carries detail 2, and the word it would look up is the dblclick
+            // handler's to name - without this it fires a second, identical lookup,
+            // which is a duplicate request and a duplicate history entry.
+            if (evt.detail > 1) {
+                return;
+            }
             // "Translate what I selected." The selection is the source of truth on
-            // this path, and the mousedown handler above is what kept it intact long
-            // enough to read.
+            // this path.
             const selection = this.getSelection();
             if (!selection) {
                 return;
@@ -384,29 +421,96 @@ class ContentScript {
             // downloads a link and Ctrl+click opens a background tab, on a word the
             // reader only meant to look up.
             evt.preventDefault();
-            this.showTranslation(selection, { of: evt });
+            this.lookUpUnlessDoubleClicked(selection, { of: evt });
         });
 
         document.addEventListener("dblclick", (evt: MouseEvent) => {
             if (!matchesTrigger(evt, this.trigger)) {
                 return;
             }
+            // A double-click supersedes the click that opened it, whose lookup is
+            // still waiting to find out whether this arrived.
+            this.cancelPendingLookup();
+
             evt.preventDefault();
             evt.stopPropagation();
 
-            // "Translate the word I am pointing at." Position is the source of truth
-            // here, not the selection: the mousedown handler means the browser never
-            // selected the word for us, and reading the selection instead would hand
-            // back whatever was left over from the last lookup. getSelection is the
-            // fallback only for the case where a page's own scripting put a live
-            // selection under the pointer.
-            const selection = wordAtPoint(evt.clientX, evt.clientY) || this.getSelection();
+            const selection = this.wordDoubleClicked(evt);
             if (!selection) {
                 return;
             }
             this.dismissOnClickOut();
             this.showTranslation(DomUtils.trim(selection), { of: evt });
         });
+    }
+
+    /**
+     * "Translate the word I am pointing at."
+     *
+     * Which of the two ways of naming that word comes first depends on whether the
+     * browser was allowed to make the selection.
+     *
+     * Where it was, its own is the better answer: it spans inline elements, so
+     * `in<em>ter</em>net` comes back whole where scanning the one text node under the
+     * pointer returns "ter", and its word segmentation knows more about language than
+     * a regular expression ever will. A double-click replaces the selection, so what
+     * it holds belongs to this gesture.
+     *
+     * Where we suppressed it, whatever is selected predates the gesture and would be
+     * a lookup of the wrong thing - so position is all there is, with the selection
+     * not consulted at all.
+     */
+    private wordDoubleClicked(evt: MouseEvent): string {
+        const atPoint = () => wordAtPoint(evt.clientX, evt.clientY);
+        if (this.selectionIsOurs()) {
+            return atPoint();
+        }
+        // caretRangeFromPoint answers for points inside the viewport only, so the
+        // browser's selection is also the fallback when position cannot answer.
+        return this.getSelection() || atPoint();
+    }
+
+    /**
+     * Whether this trigger has the extension, rather than the browser, deciding what
+     * is selected.
+     *
+     * True for Shift alone, whose own meaning is "extend the selection" - the one
+     * modifier whose default has to be suppressed. Read by everything that then has
+     * to treat the selection as untrustworthy, so the two cannot drift apart.
+     */
+    private selectionIsOurs(): boolean {
+        return this.trigger === "shift";
+    }
+
+    /**
+     * Runs a click's lookup unless the click turns out to be half of a double-click.
+     *
+     * Only needed where the mousedown default is suppressed. Everywhere else a
+     * mousedown collapses any old selection, so the first click of a double-click
+     * finds nothing to look up and returns on its own. With the default suppressed
+     * the old selection survives, and without this wait the reader gets a card for a
+     * word they selected some time ago, plus a history entry for it, every time they
+     * double-click.
+     *
+     * The wait costs a beat on the select-then-click path, and only for Shift.
+     */
+    private lookUpUnlessDoubleClicked(selection: string, anchor: CardAnchor): void {
+        if (!this.selectionIsOurs()) {
+            this.showTranslation(selection, anchor);
+            return;
+        }
+        this.cancelPendingLookup();
+        this.pendingLookup = window.setTimeout(() => {
+            this.pendingLookup = undefined;
+            this.showTranslation(selection, anchor);
+        }, DOUBLE_CLICK_GRACE_MS);
+    }
+
+    private cancelPendingLookup(): void {
+        if (this.pendingLookup !== undefined) {
+            window.clearTimeout(this.pendingLookup);
+            this.pendingLookup = undefined;
+        }
     }
 
     /**

--- a/src/scripts/content/ContentScript.ts
+++ b/src/scripts/content/ContentScript.ts
@@ -39,16 +39,6 @@ function getCardStyleSheet(): CSSStyleSheet {
 
 const HOST_CLASS = "lexinExtensionMainContainer";
 
-/**
- * How long a click waits to find out whether it was the first half of a double-click.
- *
- * Above the double-click interval every desktop ships - 500ms on Windows and on
- * macOS at the slider's slowest - so a reader whose double-click is deliberate still
- * gets one card rather than two. Only ever waited on the Shift path, so the shipped
- * trigger costs nothing.
- */
-const DOUBLE_CLICK_GRACE_MS = 550;
-
 /** Where a card points: the click that opened it, or the selection a command found. */
 type CardAnchor = Pick<PositionOptions, "of" | "fixed">;
 
@@ -80,9 +70,6 @@ class ContentScript {
 
     private zIndex = 10000;
     private clickedInsideCard = false;
-
-    /** A click's lookup, still waiting to see whether a double-click follows it. */
-    private pendingLookup: number | undefined;
 
     constructor(MessageService: IMessageService, messageHandlers: IMessageHandlers,
                 themeManager: ThemeManager, languageLabel: LanguageLabel,
@@ -417,21 +404,30 @@ class ContentScript {
             if (!selection) {
                 return;
             }
+            // Under a trigger whose selection we suppress, whatever is selected
+            // predates the gesture, and this click could as easily be the first half
+            // of a double-click aimed somewhere else - which would look up a word the
+            // reader chose some time ago and file a history entry for it.
+            //
+            // Where the click landed is what tells the two apart, and it says so at
+            // once: a reader looking their selection up clicks *on* it, and a reader
+            // starting a double-click elsewhere does not. Waiting to see whether a
+            // double-click follows would mean guessing at an interval the reader
+            // configures and Chrome does not expose.
+            if (this.selectionIsOurs() && !this.clickLandedInSelection(evt)) {
+                return;
+            }
             // The gesture is ours now, so do not also let the page have it: Alt+click
             // downloads a link and Ctrl+click opens a background tab, on a word the
             // reader only meant to look up.
             evt.preventDefault();
-            this.lookUpUnlessDoubleClicked(selection, { of: evt });
+            this.showTranslation(selection, { of: evt });
         });
 
         document.addEventListener("dblclick", (evt: MouseEvent) => {
             if (!matchesTrigger(evt, this.trigger)) {
                 return;
             }
-            // A double-click supersedes the click that opened it, whose lookup is
-            // still waiting to find out whether this arrived.
-            this.cancelPendingLookup();
-
             evt.preventDefault();
             evt.stopPropagation();
 
@@ -483,34 +479,26 @@ class ContentScript {
     }
 
     /**
-     * Runs a click's lookup unless the click turns out to be half of a double-click.
+     * Whether a click landed on the text that is currently selected.
      *
-     * Only needed where the mousedown default is suppressed. Everywhere else a
-     * mousedown collapses any old selection, so the first click of a double-click
-     * finds nothing to look up and returns on its own. With the default suppressed
-     * the old selection survives, and without this wait the reader gets a card for a
-     * word they selected some time ago, plus a history entry for it, every time they
-     * double-click.
-     *
-     * The wait costs a beat on the select-then-click path, and only for Shift.
+     * The selection's own rectangles answer it - one per line it covers - so a
+     * multi-line selection is handled without any of them having to be reasoned
+     * about here.
      */
-    private lookUpUnlessDoubleClicked(selection: string, anchor: CardAnchor): void {
-        if (!this.selectionIsOurs()) {
-            this.showTranslation(selection, anchor);
-            return;
+    private clickLandedInSelection(evt: MouseEvent): boolean {
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) {
+            return false;
         }
-        this.cancelPendingLookup();
-        this.pendingLookup = window.setTimeout(() => {
-            this.pendingLookup = undefined;
-            this.showTranslation(selection, anchor);
-        }, DOUBLE_CLICK_GRACE_MS);
-    }
-
-    private cancelPendingLookup(): void {
-        if (this.pendingLookup !== undefined) {
-            window.clearTimeout(this.pendingLookup);
-            this.pendingLookup = undefined;
+        const rects = selection.getRangeAt(0).getClientRects();
+        for (let i = 0; i < rects.length; i++) {
+            const rect = rects[i];
+            if (evt.clientX >= rect.left && evt.clientX <= rect.right
+                && evt.clientY >= rect.top && evt.clientY <= rect.bottom) {
+                return true;
+            }
         }
+        return false;
     }
 
     /**

--- a/src/scripts/content/ContentScript.ts
+++ b/src/scripts/content/ContentScript.ts
@@ -391,6 +391,14 @@ class ContentScript {
             if (!matchesTrigger(evt, this.trigger)) {
                 return;
             }
+            // Before anything that might return: once the modifier is held the gesture
+            // is the extension's, and the page does not also get it. Every trigger does
+            // something to a link - Ctrl+click opens a background tab, Alt+click
+            // downloads, Shift+click opens a window - and a reader double-clicking a
+            // linked word to look it up would get that on the first click of the pair,
+            // before the lookup had decided what the word even was.
+            evt.preventDefault();
+
             // A double-click arrives as click, click, dblclick. The second click
             // carries detail 2, and the word it would look up is the dblclick
             // handler's to name - without this it fires a second, identical lookup,
@@ -417,10 +425,6 @@ class ContentScript {
             if (this.selectionIsOurs() && !this.clickLandedInSelection(evt)) {
                 return;
             }
-            // The gesture is ours now, so do not also let the page have it: Alt+click
-            // downloads a link and Ctrl+click opens a background tab, on a word the
-            // reader only meant to look up.
-            evt.preventDefault();
             this.showTranslation(selection, { of: evt });
         });
 

--- a/src/scripts/content/WordAtPoint.ts
+++ b/src/scripts/content/WordAtPoint.ts
@@ -80,11 +80,79 @@ function caretFromPoint(x: number, y: number): ICaret | null {
     return null;
 }
 
+/**
+ * Whether an element's text runs on with the text either side of it.
+ *
+ * Only `display: inline` and `display: contents` do. An inline-block is laid out
+ * inline but is atomic - its text does not join a word across its edges - and
+ * anything block-level plainly starts afresh.
+ */
+function flowsInline(element: Element): boolean {
+    const display = window.getComputedStyle(element).display;
+    return display === "inline" || display === "contents";
+}
+
+/** The nearest ancestor that starts a fresh run of text. */
+function textContainer(node: Node): Element | null {
+    let element = node.parentElement;
+    while (element && element.parentElement && flowsInline(element)) {
+        element = element.parentElement;
+    }
+    return element;
+}
+
+/**
+ * A block's text as the reader sees it - one string across the inline elements
+ * inside it - and where `caret` lands in that string.
+ *
+ * This is what makes `h<em>u</em>nd` one word rather than three. A page splits a word
+ * whenever it emphasises, links or highlights part of it, which search results do to
+ * almost every word they show, so scanning only the text node under the pointer
+ * returns a fragment surprisingly often.
+ */
+function flowedTextAround(caret: ICaret): { text: string; offset: number } | null {
+    const container = textContainer(caret.node);
+    if (!container) {
+        return null;
+    }
+
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT, {
+        acceptNode: (node: Node) => {
+            if (node.nodeType === Node.TEXT_NODE) {
+                return NodeFilter.FILTER_ACCEPT;
+            }
+            // Descend into what runs on with its surroundings, and skip the rest
+            // whole - a nested block's text belongs to a different run.
+            return node === container || flowsInline(node as Element)
+                ? NodeFilter.FILTER_SKIP
+                : NodeFilter.FILTER_REJECT;
+        }
+    });
+
+    let text = "";
+    let offset = -1;
+    let current = walker.nextNode();
+    while (current) {
+        if (current === caret.node) {
+            offset = text.length + caret.offset;
+        }
+        text += current.textContent || "";
+        current = walker.nextNode();
+    }
+
+    return offset === -1 ? null : { text, offset };
+}
+
 /** The word under a viewport coordinate, or "" if that is not text. */
 export function wordAtPoint(x: number, y: number): string {
     const caret = caretFromPoint(x, y);
     if (!caret || caret.node.nodeType !== Node.TEXT_NODE) {
         return "";
     }
-    return wordAtOffset(caret.node.textContent || "", caret.offset);
+    // The single node is the fallback: a detached node has no container to flow in,
+    // and a caret the walker never reaches cannot be placed in the flowed text.
+    const flowed = flowedTextAround(caret);
+    return flowed
+        ? wordAtOffset(flowed.text, flowed.offset)
+        : wordAtOffset(caret.node.textContent || "", caret.offset);
 }

--- a/src/scripts/content/WordAtPoint.ts
+++ b/src/scripts/content/WordAtPoint.ts
@@ -116,31 +116,46 @@ function flowedTextAround(caret: ICaret): { text: string; offset: number } | nul
         return null;
     }
 
-    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT, {
-        acceptNode: (node: Node) => {
-            if (node.nodeType === Node.TEXT_NODE) {
-                return NodeFilter.FILTER_ACCEPT;
+    const collected = { text: "", offset: -1 };
+    collectFlowedText(container, caret, collected);
+
+    return collected.offset === -1 ? null : collected;
+}
+
+/**
+ * Appends `element`'s text to `collected`, in the order a reader reads it.
+ *
+ * Anything that ends the run of text contributes a newline rather than nothing.
+ * Eliding it would join the words either side: `bil<br>hund` would read as one word
+ * `bilhund`, and a double-click on either half would look that up. A newline is not a
+ * word character, so it separates them exactly as the reader sees them separated.
+ */
+function collectFlowedText(element: Element, caret: ICaret,
+                           collected: { text: string; offset: number }): void {
+    for (let i = 0; i < element.childNodes.length; i++) {
+        const child = element.childNodes[i];
+
+        if (child.nodeType === Node.TEXT_NODE) {
+            if (child === caret.node) {
+                collected.offset = collected.text.length + caret.offset;
             }
-            // Descend into what runs on with its surroundings, and skip the rest
-            // whole - a nested block's text belongs to a different run.
-            return node === container || flowsInline(node as Element)
-                ? NodeFilter.FILTER_SKIP
-                : NodeFilter.FILTER_REJECT;
+            collected.text += child.textContent || "";
+            continue;
         }
-    });
+        if (child.nodeType !== Node.ELEMENT_NODE) {
+            continue;
+        }
 
-    let text = "";
-    let offset = -1;
-    let current = walker.nextNode();
-    while (current) {
-        if (current === caret.node) {
-            offset = text.length + caret.offset;
+        const childElement = child as Element;
+        // A line break carries no text of its own, and a block starts a run of its
+        // own - both end this one. Neither is descended into: a nested block's text
+        // is not part of the text around the caret.
+        if (childElement.tagName === "BR" || !flowsInline(childElement)) {
+            collected.text += "\n";
+            continue;
         }
-        text += current.textContent || "";
-        current = walker.nextNode();
+        collectFlowedText(childElement, caret, collected);
     }
-
-    return offset === -1 ? null : { text, offset };
 }
 
 /** The word under a viewport coordinate, or "" if that is not text. */

--- a/src/scripts/content/WordAtPoint.ts
+++ b/src/scripts/content/WordAtPoint.ts
@@ -52,20 +52,69 @@ interface ICaretPosition {
 }
 
 type CaretDocument = Document & {
-    caretPositionFromPoint?(x: number, y: number): ICaretPosition | null;
+    caretPositionFromPoint?(x: number, y: number,
+                            options?: { shadowRoots: ShadowRoot[] }): ICaretPosition | null;
 };
+
+/** How far down a stack of nested components to follow a point. */
+const MAX_SHADOW_DEPTH = 20;
+
+/**
+ * The open shadow roots stacked under a point, outermost first.
+ *
+ * Neither caret API descends into a shadow tree on its own, and a site built out of
+ * web components keeps most of its text in one - so without this, naming a word by
+ * position fails on the pages it most needs to work on. `elementFromPoint` is what
+ * walks down: each root answers with the element under the point inside it, which may
+ * itself be another host.
+ */
+function shadowRootsAt(x: number, y: number): ShadowRoot[] {
+    const roots: ShadowRoot[] = [];
+    let element = document.elementFromPoint(x, y);
+
+    while (element?.shadowRoot && roots.length < MAX_SHADOW_DEPTH) {
+        const root = element.shadowRoot;
+        roots.push(root);
+        const inner = root.elementFromPoint(x, y);
+        if (!inner || inner === element) {
+            break;
+        }
+        element = inner;
+    }
+    return roots;
+}
 
 /**
  * The caret nearest a viewport coordinate.
  *
- * Two APIs do this and they do not share a shape: caretRangeFromPoint returns a Range
- * (startContainer/startOffset), caretPositionFromPoint the standard CaretPosition
- * (offsetNode/offset). Chrome answers the first today, so reading the second one's
- * result as a Range - as this code used to - was quietly dead rather than wrong. It
- * would have become wrong the day Chrome dropped the non-standard one.
+ * Three routes, tried in the order that answers most often:
+ *
+ * 1. `caretPositionFromPoint` told which shadow roots to look inside. The only route
+ *    that reaches text in a web component, and the option is newer than the Chrome
+ *    this extension supports - older versions ignore the dictionary member and answer
+ *    with the host instead, which is why the result is checked rather than trusted.
+ * 2. `caretRangeFromPoint`, which Chrome has always had. Returns a Range
+ *    (startContainer/startOffset).
+ * 3. `caretPositionFromPoint` on its own, the standard shape (offsetNode/offset).
+ *    Chrome answers route 2 today, so this is the one that keeps working the day it
+ *    stops.
+ *
+ * A *closed* root is out of reach for all three: nothing can enumerate one from
+ * outside. Naming a word by position cannot work there, and only the reader's own
+ * selection can - see how the double-click path falls back.
  */
 function caretFromPoint(x: number, y: number): ICaret | null {
     const doc = document as CaretDocument;
+
+    const shadowRoots = shadowRootsAt(x, y);
+    if (shadowRoots.length > 0 && doc.caretPositionFromPoint) {
+        const inShadow = doc.caretPositionFromPoint(x, y, { shadowRoots });
+        // Only worth having if it actually reached text. An older Chrome hands back
+        // the host element here, which names no word.
+        if (inShadow?.offsetNode?.nodeType === Node.TEXT_NODE) {
+            return { node: inShadow.offsetNode, offset: inShadow.offset };
+        }
+    }
 
     const range = doc.caretRangeFromPoint?.(x, y);
     if (range && range.startContainer) {

--- a/src/scripts/content/WordAtPoint.ts
+++ b/src/scripts/content/WordAtPoint.ts
@@ -1,0 +1,90 @@
+/**
+ * Naming the word under a coordinate.
+ *
+ * This used to be a fallback, reached only when a double-click left no selection
+ * behind. It is now what the double-click gesture asks first, so the gesture means
+ * "the word I am pointing at" rather than "whatever happens to be selected". That is
+ * what a reader performing it thinks it means, and it is why Shift can be a trigger
+ * at all: Shift+click's own meaning is "extend the selection", so reading the
+ * selection would grow the lookup a word at a time.
+ *
+ * The caret APIs answer for points inside the viewport only, which is no limit on a
+ * reader - they cannot click a word they cannot see - but does mean the selection
+ * fallback in the dblclick handler has to stay.
+ */
+
+/** How far either side of the caret to look. A word longer than this is not a word. */
+const SCAN = 100;
+
+/**
+ * Letters, marks, digits and the joiners that appear inside words.
+ *
+ * Deliberately not `\w`, which is ASCII-only: in a Swedish dictionary it turns `björn`
+ * into `bjrn`, and it is the accented words a reader is most likely to look up.
+ */
+const WORD_BEFORE = /[\p{L}\p{M}\p{N}_-]+$/u;
+const WORD_AFTER = /^[\p{L}\p{M}\p{N}_-]+/u;
+
+/** The word straddling `offset` in `text`, or "" if there is none. */
+export function wordAtOffset(text: string, offset: number): string {
+    if (!text) {
+        return "";
+    }
+    const clamped = Math.max(0, Math.min(text.length, offset));
+    const before = text.substring(Math.max(0, clamped - SCAN), clamped);
+    const after = text.substring(clamped, Math.min(text.length, clamped + SCAN));
+
+    const beforeMatch = before.match(WORD_BEFORE);
+    const afterMatch = after.match(WORD_AFTER);
+
+    return (beforeMatch ? beforeMatch[0] : "") + (afterMatch ? afterMatch[0] : "");
+}
+
+/** What the two caret APIs agree on, once their different shapes are set aside. */
+interface ICaret {
+    node: Node;
+    offset: number;
+}
+
+interface ICaretPosition {
+    offsetNode: Node;
+    offset: number;
+}
+
+type CaretDocument = Document & {
+    caretPositionFromPoint?(x: number, y: number): ICaretPosition | null;
+};
+
+/**
+ * The caret nearest a viewport coordinate.
+ *
+ * Two APIs do this and they do not share a shape: caretRangeFromPoint returns a Range
+ * (startContainer/startOffset), caretPositionFromPoint the standard CaretPosition
+ * (offsetNode/offset). Chrome answers the first today, so reading the second one's
+ * result as a Range - as this code used to - was quietly dead rather than wrong. It
+ * would have become wrong the day Chrome dropped the non-standard one.
+ */
+function caretFromPoint(x: number, y: number): ICaret | null {
+    const doc = document as CaretDocument;
+
+    const range = doc.caretRangeFromPoint?.(x, y);
+    if (range && range.startContainer) {
+        return { node: range.startContainer, offset: range.startOffset };
+    }
+
+    const caretPosition = doc.caretPositionFromPoint?.(x, y);
+    if (caretPosition && caretPosition.offsetNode) {
+        return { node: caretPosition.offsetNode, offset: caretPosition.offset };
+    }
+
+    return null;
+}
+
+/** The word under a viewport coordinate, or "" if that is not text. */
+export function wordAtPoint(x: number, y: number): string {
+    const caret = caretFromPoint(x, y);
+    if (!caret || caret.node.nodeType !== Node.TEXT_NODE) {
+        return "";
+    }
+    return wordAtOffset(caret.node.textContent || "", caret.offset);
+}

--- a/src/scripts/content/WordAtPoint.ts
+++ b/src/scripts/content/WordAtPoint.ts
@@ -92,6 +92,28 @@ function flowsInline(element: Element): boolean {
     return display === "inline" || display === "contents";
 }
 
+/**
+ * Whether an inline element pushes the text either side of it apart while
+ * contributing no text of its own.
+ *
+ * An `<img>` between two words does: `bil<img>hund` is two words to the reader, and
+ * collecting it as `bilhund` would look up a word that is not on the page. An empty
+ * `<span>` does not - it renders nothing, and `h<span></span>und` is still one word.
+ *
+ * Asked as "does it take up room", rather than against a list of tag names, because
+ * that is the question the reader's eye is answering. It gets `<img>`, `<svg>`,
+ * form controls and custom elements right without naming any of them; it leaves
+ * `<wbr>` and zero-width wrappers alone; and it catches an icon drawn by a
+ * `::before` rule, whose glyph never appears in `textContent` at all.
+ */
+function separatesVisually(element: Element): boolean {
+    if (element.textContent) {
+        // It has text of its own; that text is what separates, or does not.
+        return false;
+    }
+    return element.getBoundingClientRect().width > 0;
+}
+
 /** The nearest ancestor that starts a fresh run of text. */
 function textContainer(node: Node): Element | null {
     let element = node.parentElement;
@@ -151,6 +173,10 @@ function collectFlowedText(element: Element, caret: ICaret,
         // own - both end this one. Neither is descended into: a nested block's text
         // is not part of the text around the caret.
         if (childElement.tagName === "BR" || !flowsInline(childElement)) {
+            collected.text += "\n";
+            continue;
+        }
+        if (separatesVisually(childElement)) {
             collected.text += "\n";
             continue;
         }

--- a/src/scripts/content/WordAtPoint.ts
+++ b/src/scripts/content/WordAtPoint.ts
@@ -80,6 +80,11 @@ function caretFromPoint(x: number, y: number): ICaret | null {
     return null;
 }
 
+/** What the element is laid out as. */
+function displayOf(element: Element): string {
+    return window.getComputedStyle(element).display;
+}
+
 /**
  * Whether an element's text runs on with the text either side of it.
  *
@@ -87,9 +92,12 @@ function caretFromPoint(x: number, y: number): ICaret | null {
  * inline but is atomic - its text does not join a word across its edges - and
  * anything block-level plainly starts afresh.
  */
-function flowsInline(element: Element): boolean {
-    const display = window.getComputedStyle(element).display;
+function flowsInlineDisplay(display: string): boolean {
     return display === "inline" || display === "contents";
+}
+
+function flowsInline(element: Element): boolean {
+    return flowsInlineDisplay(displayOf(element));
 }
 
 /**
@@ -169,10 +177,19 @@ function collectFlowedText(element: Element, caret: ICaret,
         }
 
         const childElement = child as Element;
+        const display = displayOf(childElement);
+
+        // Nothing rendered means nothing to separate. `display: none` fails every
+        // test for flowing inline, so without this a hidden element - `hidden`,
+        // `display: none`, or a <script> the page left mid-sentence - would be taken
+        // for a block and would cut the visible word in half.
+        if (display === "none") {
+            continue;
+        }
         // A line break carries no text of its own, and a block starts a run of its
         // own - both end this one. Neither is descended into: a nested block's text
         // is not part of the text around the caret.
-        if (childElement.tagName === "BR" || !flowsInline(childElement)) {
+        if (childElement.tagName === "BR" || !flowsInlineDisplay(display)) {
             collected.text += "\n";
             continue;
         }

--- a/src/scripts/content/WordAtPoint.ts
+++ b/src/scripts/content/WordAtPoint.ts
@@ -101,25 +101,54 @@ function flowsInline(element: Element): boolean {
 }
 
 /**
- * Whether an inline element pushes the text either side of it apart while
- * contributing no text of its own.
+ * Whether any of an element's text is actually drawn.
+ *
+ * Not the same question as whether it has text. An `<svg>`'s `<title>` and a
+ * `<canvas>`'s fallback are accessible names, not words on the page: both appear in
+ * `textContent`, and both measure zero. Stopping at the first drawn node keeps the
+ * common case - an `<em>` around a syllable - to a single measurement.
+ */
+function hasRenderedText(element: Element): boolean {
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+        if (node.textContent && node.textContent.trim()) {
+            const range = document.createRange();
+            range.selectNode(node);
+            if (range.getBoundingClientRect().width > 0) {
+                return true;
+            }
+        }
+        node = walker.nextNode();
+    }
+    return false;
+}
+
+/**
+ * Whether an inline element pushes the text either side of it apart rather than
+ * joining it.
  *
  * An `<img>` between two words does: `bil<img>hund` is two words to the reader, and
  * collecting it as `bilhund` would look up a word that is not on the page. An empty
  * `<span>` does not - it renders nothing, and `h<span></span>und` is still one word.
+ * An `<svg>` with a `<title>` does, even though it has text: the title is an
+ * accessible name, and treating it as flowing text reads the page as `biliconhund`.
  *
- * Asked as "does it take up room", rather than against a list of tag names, because
- * that is the question the reader's eye is answering. It gets `<img>`, `<svg>`,
- * form controls and custom elements right without naming any of them; it leaves
- * `<wbr>` and zero-width wrappers alone; and it catches an icon drawn by a
- * `::before` rule, whose glyph never appears in `textContent` at all.
+ * Both halves are asked geometrically - does it take up room, and is any of its text
+ * drawn - rather than against a list of tag names, because that is what the reader's
+ * eye is answering. It gets `<img>`, `<svg>`, `<canvas>`, `<video>`, form controls and
+ * custom elements right without naming any of them; it leaves `<wbr>` and zero-width
+ * wrappers alone; and it catches an icon drawn by a `::before` rule, whose glyph never
+ * appears in `textContent` at all.
  */
 function separatesVisually(element: Element): boolean {
-    if (element.textContent) {
-        // It has text of its own; that text is what separates, or does not.
+    if (element.getBoundingClientRect().width === 0) {
+        // It takes up no room, so it holds nothing apart.
         return false;
     }
-    return element.getBoundingClientRect().width > 0;
+    // It takes up room. Whether that room is a gap between two words or the words
+    // themselves depends on whether the text in it is on the page.
+    return !hasRenderedText(element);
 }
 
 /** The nearest ancestor that starts a fresh run of text. */

--- a/src/scripts/content/content.ts
+++ b/src/scripts/content/content.ts
@@ -4,6 +4,7 @@ import ContentScript from "./ContentScript.js";
 import ThemeManager from "../common/ThemeManager.js";
 import LanguageLabel from "../common/LanguageLabel.js";
 import DictionaryFactory from "../dictionary/DictionaryFactory.js";
+import Settings, { TRIGGER_MODIFIER_KEY } from "../common/Settings.js";
 import { createChromeStorage } from "../common/ChromeStorageAdapter.js";
 
 const messageService = new MessageService();
@@ -22,6 +23,24 @@ const contentScript = new ContentScript(
     messageService,
     messageHandlers,
     new ThemeManager(settingsStorage),
-    new LanguageLabel(settingsStorage, languages)
+    new LanguageLabel(settingsStorage, languages),
+    new Settings(settingsStorage)
 );
 contentScript.initialize();
+
+// The one setting that cannot wait for the next card, and the extension's only
+// storage subscription.
+//
+// Every other setting is re-read by the action that displays it, so staleness heals
+// itself after one card. The trigger cannot work that way: a reader changes it
+// precisely because their desktop intercepts the current one, so the page they were
+// reading has no way to open a card and re-read on its own. Waiting would look
+// exactly like the setting doing nothing.
+//
+// The key check comes first because this fires for every write to local storage,
+// including the history append behind every lookup, in every frame of the page.
+chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName === "local" && TRIGGER_MODIFIER_KEY in changes) {
+        contentScript.refreshTrigger();
+    }
+});

--- a/src/scripts/help-main.ts
+++ b/src/scripts/help-main.ts
@@ -1,6 +1,8 @@
 import * as DomUtils from "./util/DomUtils.js";
 import * as Icons from "./util/Icons.js";
 import ThemeManager, { applyTheme } from "./common/ThemeManager.js";
+import Settings from "./common/Settings.js";
+import { gestureLabel } from "./common/LookupTrigger.js";
 import { createChromeStorage } from "./common/ChromeStorageAdapter.js";
 
 /**
@@ -23,6 +25,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     // a dark desktop.
     const themeManager = new ThemeManager(settingsStorage);
     applyTheme(document.documentElement, await themeManager.getTheme());
+
+    // Steps 1 and 2 name a key the reader chose, so instructions that told them to
+    // hold Alt would be wrong for exactly the readers who had to change it.
+    const modifier = await new Settings(settingsStorage).getTriggerModifier();
+    DomUtils.setText(DomUtils.$("#stepDoubleClick"),
+        `${gestureLabel(modifier, "double-click")} a word`);
+    DomUtils.setText(DomUtils.$("#stepClick"),
+        `Select, then ${gestureLabel(modifier, "click")}`);
 
     DomUtils.each(DomUtils.$$(".lxStepIcon"), (_index, element) => {
         const icon = STEP_ICONS[DomUtils.getAttr(element, "data-icon")];

--- a/src/scripts/history/HistoryModel.ts
+++ b/src/scripts/history/HistoryModel.ts
@@ -1,6 +1,7 @@
 import { IMessageService, IHistoryItem } from "../common/Interfaces.js";
 import LanguageManager from "../common/LanguageManager.js";
 import Settings from "../common/Settings.js";
+import { TriggerModifier } from "../common/LookupTrigger.js";
 
 /** A history entry plus which Language Direction it came from. */
 export interface IHistoryRow extends IHistoryItem {
@@ -40,6 +41,14 @@ class HistoryModel {
 
     setRecordHistory(value: boolean): Promise<void> {
         return this.settings.setRecordHistory(value);
+    }
+
+    /**
+     * The gesture that opens a Translation Card, so the empty state can tell a reader
+     * how to fill the list using the key they actually chose.
+     */
+    getTriggerModifier(): Promise<TriggerModifier> {
+        return this.settings.getTriggerModifier();
     }
 
     /**

--- a/src/scripts/history/HistoryPage.ts
+++ b/src/scripts/history/HistoryPage.ts
@@ -7,6 +7,7 @@ import * as HistoryExport from "./HistoryExport.js";
 import { confirmDialog } from "../util/Dialog.js";
 import { showToast } from "../util/Toast.js";
 import { fold } from "../util/Combobox.js";
+import { DEFAULT_TRIGGER, gestureLabel, TriggerModifier } from "../common/LookupTrigger.js";
 
 /** Identifies a row across a re-render, so selection survives searching. */
 function rowKey(row: IHistoryRow): string {
@@ -41,6 +42,9 @@ class HistoryPage {
     private query = "";
     private recording = true;
 
+    /** Cached so renderTable, which is synchronous, can name the gesture. */
+    private trigger: TriggerModifier = DEFAULT_TRIGGER;
+
     constructor(model: HistoryModel, languageLabel: LanguageLabel) {
         this.model = model;
         this.languageLabel = languageLabel;
@@ -52,6 +56,7 @@ class HistoryPage {
 
         this.readerLanguage = await this.model.getLanguage();
         this.recording = await this.model.getRecordHistory();
+        this.trigger = await this.model.getTriggerModifier();
         this.directions = this.sortDirections(await this.model.loadDirections());
 
         // Open on the reader's own language when it has history; otherwise All, which
@@ -187,7 +192,8 @@ class HistoryPage {
             DomUtils.append(container, this.recording
                 ? States.emptyState(
                     "No translations yet",
-                    "Alt + double-click a word on any Swedish page to start building your list.")
+                    `${gestureLabel(this.trigger, "double-click")} a word on any Swedish page ` +
+                    "to start building your list.")
                 : States.emptyState(
                     "Recording is off",
                     "Lookups are not being saved, so this list stays empty.",

--- a/src/scripts/messaging/ChromeMessageBus.ts
+++ b/src/scripts/messaging/ChromeMessageBus.ts
@@ -55,6 +55,34 @@ class ChromeMessageBus implements IMessageBus {
     createNewTab(url: string): void {
         chrome.tabs.create({"url": url}, function () {});
     }
+
+    /**
+     * Chrome delivers a keyboard shortcut to the service worker and nowhere else, so
+     * this is the only way into the extension for one.
+     *
+     * Must be registered synchronously while the worker starts up: the worker sleeps
+     * between events, and a listener attached later - inside a promise, say - is not
+     * there when Chrome wakes it for the keystroke, which is then simply lost.
+     */
+    registerCommandHandler(command: string, handler: () => void): void {
+        chrome.commands.onCommand.addListener(function (name: string) {
+            if (name === command) {
+                handler();
+            }
+        });
+    }
+
+    getCommandShortcut(command: string): Promise<string> {
+        return new Promise((resolve) => {
+            chrome.commands.getAll(function (commands) {
+                const match = commands.filter((c) => c.name === command)[0];
+                // An unassigned command still appears, with an empty shortcut - which
+                // is what Chrome does when another extension already holds the
+                // suggested combination.
+                resolve(match?.shortcut || "");
+            });
+        });
+    }
 }
 
 export default ChromeMessageBus;

--- a/src/scripts/messaging/MessageHandlers.ts
+++ b/src/scripts/messaging/MessageHandlers.ts
@@ -1,6 +1,7 @@
 import { IMessageHandlers, GetTranslationHandler, LoadHistoryHandler, ClearHistoryHandler,
     GetSelectionHandler, OpenActionPopupHandler, LoadHistoryDirectionsHandler,
-    RemoveHistoryItemHandler, PlayAudioHandler } from "../common/Interfaces.js";
+    RemoveHistoryItemHandler, PlayAudioHandler,
+    TranslateSelectionHandler } from "../common/Interfaces.js";
 import MessageType from "./MessageType.js";
 import MessageBus from "./MessageBus.js";
 
@@ -58,6 +59,15 @@ class MessageHandlers implements IMessageHandlers{
         MessageBus.Instance.registerHandler(MessageType.playAudioInOffscreenDocument, (args: any) => {
             return handler(args.url);
         });
+    }
+
+    registerTranslateSelectionHandler(handler: TranslateSelectionHandler): void {
+        // ignoreEmptyResult, for the same reason getSelection sets it: every frame on
+        // the page is asked and only the one holding the selection answers, so a
+        // silent frame must not send an empty response back.
+        MessageBus.Instance.registerHandler(MessageType.translateSelection, (_args) => {
+            return handler();
+        }, true);
     }
 }
 

--- a/src/scripts/messaging/MessageService.ts
+++ b/src/scripts/messaging/MessageService.ts
@@ -47,6 +47,21 @@ class MessageService implements IMessageService{
         return MessageBus.Instance.sendMessage(MessageType.playAudio, {url: url});
     }
 
+    /**
+     * Sent to every frame of the active tab, because the worker cannot know which one
+     * the reader is in. Frames with no selection stay silent, so the bus resolves
+     * undefined where nothing was selected anywhere - an ordinary outcome, and the
+     * reason nothing here treats it as an error.
+     */
+    translateSelection(): Promise<void> {
+        return MessageBus.Instance.sendMessageToActiveTab(MessageType.translateSelection)
+            .then(() => undefined);
+    }
+
+    getCommandShortcut(command: string): Promise<string> {
+        return MessageBus.Instance.getCommandShortcut(command);
+    }
+
     openActionPopup(): Promise<void> {
         // Only the service worker can open the Action Popup, so this is a message
         // rather than a direct call - the Translation Card's expand button runs in a

--- a/src/scripts/messaging/MessageType.ts
+++ b/src/scripts/messaging/MessageType.ts
@@ -17,7 +17,13 @@ enum MessageType {
      * Action Popup would arrive at the worker *and* at an already-open Offscreen
      * Document, and the worker's forward would play it a second time.
      */
-    playAudioInOffscreenDocument
+    playAudioInOffscreenDocument,
+    /**
+     * The service worker -> every frame of the active tab: open a card on whatever is
+     * selected. Sent when the reader presses the extension's keyboard shortcut, which
+     * Chrome delivers to the worker and nowhere else.
+     */
+    translateSelection
 }
 
 export default MessageType;

--- a/src/scripts/options/OptionsPage.ts
+++ b/src/scripts/options/OptionsPage.ts
@@ -5,10 +5,16 @@ import { fold } from "../util/Combobox.js";
 import LanguageManager from "../common/LanguageManager.js";
 import ThemeManager, { Appearance, applyTheme } from "../common/ThemeManager.js";
 import Settings from "../common/Settings.js";
-import { ILanguage } from "../common/Interfaces.js";
+import { availableModifiers, modifierLabel, TRANSLATE_SELECTION_COMMAND,
+    TriggerModifier } from "../common/LookupTrigger.js";
+import { ILanguage, IMessageService } from "../common/Interfaces.js";
+
+/** Chrome's own shortcuts UI. Not linkable from an extension page - see below. */
+const SHORTCUTS_URL = "chrome://extensions/shortcuts";
 
 class OptionsPage {
 
+    private messageService: IMessageService;
     private languageManager: LanguageManager;
     private themeManager: ThemeManager;
     private settings: Settings;
@@ -18,7 +24,9 @@ class OptionsPage {
     private defaultLanguage: string = "";
     private query = "";
 
-    constructor(languageManager: LanguageManager, themeManager: ThemeManager, settings: Settings) {
+    constructor(messageService: IMessageService, languageManager: LanguageManager,
+                themeManager: ThemeManager, settings: Settings) {
+        this.messageService = messageService;
         this.languageManager = languageManager;
         this.themeManager = themeManager;
         this.settings = settings;
@@ -172,6 +180,51 @@ class OptionsPage {
         if (recordInput) {
             recordInput.checked = true;
         }
+
+        this.renderModifierOptions();
+        const trigger = await this.settings.getTriggerModifier();
+        const triggerInput = DomUtils.$(`#triggerModifier input[value='${trigger}']`) as HTMLInputElement;
+        if (triggerInput) {
+            triggerInput.checked = true;
+        }
+
+        await this.renderShortcut();
+    }
+
+    /**
+     * Drops the modifiers this platform cannot deliver, and names the rest as the
+     * keyboard in front of the reader has them engraved.
+     *
+     * The markup ships all three so the page still reads correctly with no script;
+     * this is what makes it honest on a Mac, where Ctrl+click is the secondary click
+     * and the gesture could never fire.
+     */
+    private renderModifierOptions(): void {
+        const usable = availableModifiers();
+        const mac = usable.indexOf("ctrl") === -1;
+
+        DomUtils.each(DomUtils.$$("#triggerModifier .lxSegOption"), (_index, option) => {
+            const input = option.querySelector("input") as HTMLInputElement;
+            const modifier = input?.value as TriggerModifier;
+            if (!modifier || usable.indexOf(modifier) === -1) {
+                DomUtils.remove(option);
+                return;
+            }
+            DomUtils.setText(option.querySelector("span"), modifierLabel(modifier, mac));
+        });
+    }
+
+    /**
+     * Shows what the shortcut is actually bound to.
+     *
+     * Chrome silently leaves the suggested combination unassigned when another
+     * extension already holds it, and nothing else in the UI would ever say so - a
+     * reader would just press it and get nothing.
+     */
+    private async renderShortcut(): Promise<void> {
+        const shortcut = await this.messageService.getCommandShortcut(TRANSLATE_SELECTION_COMMAND);
+        const button = DomUtils.$("#openShortcuts");
+        DomUtils.setText(button, shortcut ? `Keyboard shortcut: ${shortcut}` : "Set a keyboard shortcut…");
     }
 
     private subscribeOnEvents(): void {
@@ -197,6 +250,23 @@ class OptionsPage {
             const recording = (e.target as HTMLInputElement).value === "on";
             await this.settings.setRecordHistory(recording);
             showToast("Options saved");
+        });
+
+        DomUtils.$("#triggerModifier")?.addEventListener("change", async (e: Event) => {
+            const modifier = (e.target as HTMLInputElement).value as TriggerModifier;
+            await this.settings.setTriggerModifier(modifier);
+            // Pages already open pick this up without a reload - see the storage
+            // subscription in content.ts, and why the trigger is the one setting that
+            // gets one.
+            showToast("Options saved");
+        });
+
+        DomUtils.$("#openShortcuts")?.addEventListener("click", () => {
+            // A button rather than a link because Chrome blocks a navigation to a
+            // chrome:// URL from an extension page. tabs.create is the way there, and
+            // it needs no permission. The hint spells the URL out so a reader can
+            // reach it by hand if this ever stops working.
+            this.messageService.createNewTab(SHORTCUTS_URL);
         });
     }
 }

--- a/src/scripts/options/options.ts
+++ b/src/scripts/options/options.ts
@@ -3,6 +3,7 @@ import OptionsPage from "./OptionsPage.js";
 import LanguageManager from "../common/LanguageManager.js";
 import ThemeManager, { applyTheme } from "../common/ThemeManager.js";
 import Settings from "../common/Settings.js";
+import MessageService from "../messaging/MessageService.js";
 import { createChromeStorage } from "../common/ChromeStorageAdapter.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -16,5 +17,5 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const dictionaryFactory = new DictionaryFactory();
     const languageManager = new LanguageManager(settingsStorage, dictionaryFactory);
-    new OptionsPage(languageManager, themeManager, new Settings(settingsStorage));
+    new OptionsPage(new MessageService(), languageManager, themeManager, new Settings(settingsStorage));
 });

--- a/src/scripts/popup/PopupPage.ts
+++ b/src/scripts/popup/PopupPage.ts
@@ -7,6 +7,8 @@ import * as Icons from "../util/Icons.js";
 import * as States from "../util/States.js";
 import Combobox from "../util/Combobox.js";
 import { processTranslationHtml } from "../util/TranslationUtils.js";
+import Settings from "../common/Settings.js";
+import { DEFAULT_TRIGGER, gestureLabel, TriggerModifier } from "../common/LookupTrigger.js";
 
 /** How many past lookups the Recent row offers. */
 const RECENT_COUNT = 5;
@@ -30,11 +32,17 @@ class PopupPage {
     private languageManager: LanguageManager;
     private languageLabel: LanguageLabel;
     private languagePicker: Combobox;
+    private settings: Settings;
 
-    constructor(MessageService: IMessageService, languageManager: LanguageManager, languageLabel: LanguageLabel) {
+    /** Cached so the empty state, which renders synchronously, can name the gesture. */
+    private trigger: TriggerModifier = DEFAULT_TRIGGER;
+
+    constructor(MessageService: IMessageService, languageManager: LanguageManager,
+                languageLabel: LanguageLabel, settings: Settings) {
         this.messageService = MessageService;
         this.languageManager = languageManager;
         this.languageLabel = languageLabel;
+        this.settings = settings;
 
         this.initialize();
     }
@@ -51,6 +59,9 @@ class PopupPage {
         this.currentDirection = await this.getSavedDirection();
         await this.useSupportedDirection();
         this.renderDirectionBadge();
+
+        // Read before translateSelectedWord, which renders the empty state naming it.
+        this.trigger = await this.settings.getTriggerModifier();
 
         this.translateSelectedWord();
         this.refreshRecent();
@@ -208,7 +219,7 @@ class PopupPage {
             } else {
                 States.render(DomUtils.$("#translation") as HTMLElement, States.emptyState(
                     "No word selected",
-                    "Alt + double-click a word on the page, or type above."));
+                    `${gestureLabel(this.trigger, "double-click")} a word on the page, or type above.`));
             }
         });
     }

--- a/src/scripts/popup/popup.ts
+++ b/src/scripts/popup/popup.ts
@@ -4,6 +4,7 @@ import LanguageManager from "../common/LanguageManager.js";
 import LanguageLabel from "../common/LanguageLabel.js";
 import ThemeManager, { applyTheme } from "../common/ThemeManager.js";
 import PopupPage from "./PopupPage.js";
+import Settings from "../common/Settings.js";
 import { createChromeStorage } from "../common/ChromeStorageAdapter.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -19,5 +20,5 @@ document.addEventListener("DOMContentLoaded", async () => {
     const dictionaryFactory = new DictionaryFactory();
     const languageManager = new LanguageManager(settingsStorage, dictionaryFactory);
     const languageLabel = new LanguageLabel(settingsStorage, dictionaryFactory.getAllSupportedLanguages());
-    new PopupPage(messageService, languageManager, languageLabel);
+    new PopupPage(messageService, languageManager, languageLabel, new Settings(settingsStorage));
 });

--- a/src/scripts/util/Icons.ts
+++ b/src/scripts/util/Icons.ts
@@ -106,14 +106,14 @@ export function search(size: number = 14): SVGElement {
  * their second or third language - which is most of them.
  */
 
-/** Lucide "keyboard" - the Alt + double-click gesture. */
+/** Lucide "keyboard" - the modifier + double-click gesture. */
 export function keyboard(size: number = 28): SVGElement {
     const svg = withPath(createSvg(size), "M3 4h18a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1z");
     withPath(svg, "M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M7 16h10");
     return svg;
 }
 
-/** Lucide "mouse-pointer-click" - select first, then Alt + click. */
+/** Lucide "mouse-pointer-click" - select first, then modifier + click. */
 export function pointer(size: number = 28): SVGElement {
     const svg = withPath(createSvg(size), "M9 9l5 12 1.774-5.226L21 14 9 9z");
     withPath(svg, "M16.071 16.071l4.243 4.243M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122M5.136 16.035l-2.898.777");

--- a/src/scripts/util/PositionUtils.ts
+++ b/src/scripts/util/PositionUtils.ts
@@ -7,6 +7,15 @@ export interface PositionOptions {
     my?: string; // e.g., "center+10 bottom-20"
     at?: string; // e.g., "center top"
     collision?: string; // "flip", "fit", "flipfit", "none"
+    /**
+     * Whether `of`'s coordinates are viewport-relative, and so whether the element is
+     * placed with `fixed` rather than `absolute`.
+     *
+     * Inferred from `of` being a MouseEvent when omitted, which is how every caller
+     * used to get fixed positioning. A caller holding a Range's getBoundingClientRect
+     * - viewport coordinates, but not a MouseEvent - says so explicitly.
+     */
+    fixed?: boolean;
 }
 
 interface ParsedAlignment {
@@ -257,7 +266,7 @@ export function position(element: HTMLElement, options: PositionOptions): void {
 
     // For mouse events, use fixed positioning (viewport-relative) for better UX
     // For elements, we can use either, but fixed is simpler
-    const useFixed = options.of instanceof MouseEvent;
+    const useFixed = options.fixed !== undefined ? options.fixed : options.of instanceof MouseEvent;
     
     const targetPos = getTargetPosition(options.of, useFixed);
     let elementRect = element.getBoundingClientRect();

--- a/src/scripts/worker/BackgroundWorker.ts
+++ b/src/scripts/worker/BackgroundWorker.ts
@@ -1,6 +1,8 @@
 import { IHistoryManager, ITranslation, ITranslationManager, IMessageHandlers,
-    IAudioPlayer } from "../common/Interfaces.js";
+    IAudioPlayer, IMessageBus } from "../common/Interfaces.js";
 import TranslationDirection from "../dictionary/TranslationDirection.js";
+import MessageType from "../messaging/MessageType.js";
+import { TRANSLATE_SELECTION_COMMAND } from "../common/LookupTrigger.js";
 
 class BackgroundWorker {
 
@@ -8,13 +10,16 @@ class BackgroundWorker {
     private translationManager: ITranslationManager;
     private messageHandlers: IMessageHandlers;
     private audioPlayer: IAudioPlayer;
+    private messageBus: IMessageBus;
 
     constructor(historyManager : IHistoryManager, translationManager: ITranslationManager,
-                messageHandlers: IMessageHandlers, audioPlayer: IAudioPlayer) {
+                messageHandlers: IMessageHandlers, audioPlayer: IAudioPlayer,
+                messageBus: IMessageBus) {
         this.historyManager = historyManager;
         this.translationManager = translationManager;
         this.messageHandlers = messageHandlers;
         this.audioPlayer = audioPlayer;
+        this.messageBus = messageBus;
     }
 
     getTranslation(word: string, direction: TranslationDirection): Promise<ITranslation> {
@@ -60,7 +65,26 @@ class BackgroundWorker {
         return this.audioPlayer.play(url);
     }
 
+    /**
+     * Asks the active tab to look up its selection, on the reader's keyboard shortcut.
+     *
+     * A shortcut is the one trigger no desktop can intercept, which is the whole
+     * reason it exists: ChromeOS and GNOME both take Alt+click for themselves before
+     * the page is sent anything. Where nothing is selected no frame answers and this
+     * quietly does nothing - the same outcome as on a page the content script cannot
+     * run on, and better than a panel opening at a keystroke that found no word.
+     */
+    translateSelection(): Promise<void> {
+        return this.messageBus.sendMessageToActiveTab(MessageType.translateSelection)
+            .then(() => undefined);
+    }
+
     initialize(): void {
+        // Registered synchronously, while the worker is starting: it sleeps between
+        // events, and a listener attached later is not there when Chrome wakes it for
+        // the keystroke.
+        this.messageBus.registerCommandHandler(TRANSLATE_SELECTION_COMMAND,
+            () => this.translateSelection());
         this.messageHandlers.registerGetTranslationHandler((word, direction) => this.getTranslation(word, direction));
         this.messageHandlers.registerLoadHistoryHandler((langDirection) => this.historyManager.getHistory(langDirection));
         this.messageHandlers.registerClearHistoryHandler((langDirection) => this.historyManager.clearHistory(langDirection));

--- a/src/scripts/worker/background.ts
+++ b/src/scripts/worker/background.ts
@@ -6,6 +6,7 @@ import LanguageManager from "../common/LanguageManager.js";
 import Settings from "../common/Settings.js";
 import BackgroundWorker from "./BackgroundWorker.js";
 import MessageHandlers from "../messaging/MessageHandlers.js";
+import MessageBus from "../messaging/MessageBus.js";
 import { createChromeStorage } from "../common/ChromeStorageAdapter.js";
 import FetchLoader from "../dictionary/FetchLoader.js";
 import LexinDictionary from "../dictionary/LexinDictionary.js";
@@ -36,7 +37,7 @@ try {
     const translationManager = new TranslationManager(historyManager, dictionaryFactory, languageManager, settings);
     const messageHandlers = new MessageHandlers();
     const backgroundWorker = new BackgroundWorker(historyManager, translationManager, messageHandlers,
-        new OffscreenAudioPlayer());
+        new OffscreenAudioPlayer(), MessageBus.Instance);
     
     backgroundWorker.initialize();
     

--- a/tests/e2e/audio-playback.spec.ts
+++ b/tests/e2e/audio-playback.spec.ts
@@ -24,13 +24,8 @@ const EXPECTED_TRANSLATION = "ett fordon för ett litet antal personer";
 
 /** Alt+Double click the fixture's test word and wait for the card to fill in. */
 async function summonCard(page: Page) {
-    const testWord = page.locator("#test-word");
-    await expect(testWord).toBeVisible();
-    const box = await testWord.boundingBox();
-
-    await page.keyboard.down("Alt");
-    await page.mouse.dblclick(box!.x + box!.width / 2, box!.y + box!.height / 2);
-    await page.keyboard.up("Alt");
+    await expect(page.locator("#test-word")).toBeVisible();
+    await ExtensionHelpers.triggerLookup(page, "#test-word");
 
     // Locators pierce the open shadow root the card renders in.
     const content = page.locator(".lexinTranslationContent");

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -169,6 +169,59 @@ export class ExtensionHelpers {
     await page.close();
   }
 
+  /**
+   * Put the extension on a lookup modifier without walking the Options page.
+   *
+   * Stored as the string Settings writes. Note the Options page never offers "ctrl"
+   * on a Mac, so a test seeding it there is testing the fallback, not the gesture.
+   */
+  static async setTriggerModifier(
+    context: BrowserContext, extensionId: string, value: "alt" | "ctrl" | "shift"
+  ): Promise<void> {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/html/help.html`);
+    await page.waitForLoadState("domcontentloaded");
+    await page.evaluate(async (modifier) => {
+      await chrome.storage.local.set({ triggerModifier: modifier });
+    }, value);
+    await page.close();
+  }
+
+  /**
+   * Perform the on-page lookup gesture, the way a reader performs it.
+   *
+   * Defaults to the shipped Alt + double-click, so the many call sites that are not
+   * *about* the trigger say nothing about it and keep working when the default moves.
+   *
+   * Worth knowing what this cannot do: Playwright drives Chrome over CDP, which
+   * injects input below the layer where ChromeOS and GNOME take Alt+click for
+   * themselves. The bug the configurable trigger exists to fix is not reproducible
+   * here on any platform - only that the configuration works.
+   */
+  static async triggerLookup(
+    page: Page,
+    selector: string,
+    options?: { modifier?: "Alt" | "Control" | "Shift"; gesture?: "click" | "dblclick" }
+  ): Promise<void> {
+    const modifier = options?.modifier ?? "Alt";
+    const gesture = options?.gesture ?? "dblclick";
+
+    const box = await page.locator(selector).boundingBox();
+    if (!box) {
+      throw new Error(`No bounding box for ${selector} - is it visible?`);
+    }
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+
+    await page.keyboard.down(modifier);
+    if (gesture === "dblclick") {
+      await page.mouse.dblclick(x, y);
+    } else {
+      await page.mouse.click(x, y);
+    }
+    await page.keyboard.up(modifier);
+  }
+
   /** Reads one settings key back, for assertions about what a surface persisted. */
   static async getStoredValue(
     context: BrowserContext, extensionId: string, key: string

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,4 +1,13 @@
 import { test, expect, ExtensionHelpers } from "./fixtures";
+import { gestureLabel } from "../../src/scripts/common/LookupTrigger";
+
+/**
+ * The shipped gesture, spelled as the reader's own keyboard has it engraved - a Mac
+ * says Option where everything else says Alt. Computed with the product's own
+ * formatter rather than hardcoded, so this suite reads the same on a developer's
+ * laptop as it does on the Linux box in CI.
+ */
+const DEFAULT_GESTURE = gestureLabel("alt", "double-click", process.platform === "darwin");
 
 /**
  * Smoke tests for the Lexin Dictionary Chrome Extension.
@@ -287,14 +296,14 @@ test.describe("Extension Smoke Tests", () => {
 
     const page = await historyPage();
 
-    // Not "Alt + double-click to start building your list" - that advice builds
+    // Not "<gesture> to start building your list" - that advice builds
     // nothing while recording is off.
     await expect(page.locator("#history")).toContainText("Recording is off");
-    await expect(page.locator("#history")).not.toContainText("Alt + double-click");
+    await expect(page.locator("#history")).not.toContainText(DEFAULT_GESTURE);
     await page.locator("#history .lxButton").click();
 
     await expect(page.locator("#history")).toContainText("No translations yet");
-    await expect(page.locator("#history")).toContainText("Alt + double-click");
+    await expect(page.locator("#history")).toContainText(DEFAULT_GESTURE);
 
     await page.close();
   });
@@ -322,7 +331,7 @@ test.describe("Extension Smoke Tests", () => {
     const page = await historyPage();
 
     await expect(page.locator("#history")).toContainText("No translations yet");
-    await expect(page.locator("#history")).toContainText("Alt + double-click");
+    await expect(page.locator("#history")).toContainText(DEFAULT_GESTURE);
     // Nothing to export or clear, so neither offers itself.
     await expect(page.locator("#exportButton")).toBeDisabled();
     await expect(page.locator("#clearHistory")).toBeDisabled();
@@ -560,7 +569,7 @@ test.describe("Extension Smoke Tests", () => {
     // The Alt+double-click hint used to live in a dismissible blue banner that was
     // shown whether or not it was any use. It now rides on the empty state, which is
     // exactly when a reader has not discovered the gesture.
-    await expect(page.locator("#translation")).toContainText("Alt + double-click");
+    await expect(page.locator("#translation")).toContainText(DEFAULT_GESTURE);
     await expect(page.locator("#quickTip")).toHaveCount(0);
 
     await page.close();
@@ -596,7 +605,7 @@ test.describe("Extension Smoke Tests", () => {
     // Three gestures, each drawn rather than described in a numbered paragraph.
     const steps = page.locator(".lxStep");
     await expect(steps).toHaveCount(3);
-    await expect(steps.first()).toContainText("Alt + double-click a word");
+    await expect(steps.first()).toContainText(`${DEFAULT_GESTURE} a word`);
     await expect(page.locator(".lxStepIcon svg")).toHaveCount(3);
 
     // The eight-step manual Quizlet walkthrough is replaced by pointing at the
@@ -988,14 +997,7 @@ test.describe("Extension Smoke Tests", () => {
     // Find and click on the test word "bil"
     const testWord = page.locator("#test-word");
     await expect(testWord).toBeVisible();
-    const boundingBox = await testWord.boundingBox();
-    const clickX = boundingBox!.x + boundingBox!.width / 2;
-    const clickY = boundingBox!.y + boundingBox!.height / 2;
-    
-    // Alt + Double click
-    await page.keyboard.down("Alt");
-    await page.mouse.dblclick(clickX, clickY);
-    await page.keyboard.up("Alt");
+    await ExtensionHelpers.triggerLookup(page, "#test-word");
     
     // Verify translation popup appears with Swedish definition
     const translationContent = page.locator(".lexinTranslationContent");
@@ -1018,14 +1020,7 @@ test.describe("Extension Smoke Tests", () => {
     // Find and click on the test word "bil"
     const testWord = page.locator("#test-word");
     await expect(testWord).toBeVisible();
-    const boundingBox = await testWord.boundingBox();
-    const clickX = boundingBox!.x + boundingBox!.width / 2;
-    const clickY = boundingBox!.y + boundingBox!.height / 2;
-    
-    // Alt + Double click
-    await page.keyboard.down("Alt");
-    await page.mouse.dblclick(clickX, clickY);
-    await page.keyboard.up("Alt");
+    await ExtensionHelpers.triggerLookup(page, "#test-word");
     
     // Verify translation popup appears with English translation
     const translationContent = page.locator(".lexinTranslationContent");
@@ -1049,13 +1044,7 @@ test.describe("Extension Smoke Tests", () => {
 
     const testWord = page.locator("#test-word");
     await expect(testWord).toBeVisible();
-    const boundingBox = await testWord.boundingBox();
-    const clickX = boundingBox!.x + boundingBox!.width / 2;
-    const clickY = boundingBox!.y + boundingBox!.height / 2;
-
-    await page.keyboard.down("Alt");
-    await page.mouse.dblclick(clickX, clickY);
-    await page.keyboard.up("Alt");
+    await ExtensionHelpers.triggerLookup(page, "#test-word");
 
     // Locators pierce the open shadow root.
     const header = page.locator(".lexinCardHeader");
@@ -1082,11 +1071,7 @@ test.describe("Extension Smoke Tests", () => {
     await page.waitForLoadState("domcontentloaded");
     await page.waitForTimeout(500);
 
-    const testWord = page.locator("#test-word");
-    const boundingBox = await testWord.boundingBox();
-    await page.keyboard.down("Alt");
-    await page.mouse.dblclick(boundingBox!.x + boundingBox!.width / 2, boundingBox!.y + boundingBox!.height / 2);
-    await page.keyboard.up("Alt");
+    await ExtensionHelpers.triggerLookup(page, "#test-word");
 
     const content = page.locator(".lexinTranslationContent");
     await expect(content).toContainText("ett fordon för ett litet antal personer", { timeout: 15000 });
@@ -1112,14 +1097,7 @@ test.describe("Extension Smoke Tests", () => {
     // Find and click on the test word "bil"
     const testWord = page.locator("#test-word");
     await expect(testWord).toBeVisible();
-    const boundingBox = await testWord.boundingBox();
-    const clickX = boundingBox!.x + boundingBox!.width / 2;
-    const clickY = boundingBox!.y + boundingBox!.height / 2;
-    
-    // Alt + Double click
-    await page.keyboard.down("Alt");
-    await page.mouse.dblclick(clickX, clickY);
-    await page.keyboard.up("Alt");
+    await ExtensionHelpers.triggerLookup(page, "#test-word");
     
     // Verify translation popup appears with Russian translation
     const translationContent = page.locator(".lexinTranslationContent");

--- a/tests/e2e/style-isolation.spec.ts
+++ b/tests/e2e/style-isolation.spec.ts
@@ -31,13 +31,8 @@ const EXPECTED_TRANSLATION = "ett fordon för ett litet antal personer";
  * the host page's CSS was reaching.
  */
 async function summonCard(page: import("@playwright/test").Page) {
-    const testWord = page.locator("#test-word");
-    await expect(testWord).toBeVisible();
-    const box = await testWord.boundingBox();
-
-    await page.keyboard.down("Alt");
-    await page.mouse.dblclick(box!.x + box!.width / 2, box!.y + box!.height / 2);
-    await page.keyboard.up("Alt");
+    await expect(page.locator("#test-word")).toBeVisible();
+    await ExtensionHelpers.triggerLookup(page, "#test-word");
 
     // Locators pierce the open shadow root, so this finds the card's content area.
     const content = page.locator(".lexinTranslationContent");

--- a/tests/e2e/test-pages/framed-text.html
+++ b/tests/e2e/test-pages/framed-text.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <title>Framed Swedish Test Page</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 30px; font-size: 18px; }
+        iframe { width: 90%; height: 220px; border: 2px solid #999; }
+    </style>
+</head>
+<body>
+    <!--
+        A page with a word of its own and an iframe holding another.
+
+        The content script runs in every frame, so the keyboard shortcut is delivered
+        to both. Each document keeps whatever it had selected last and each reports
+        hasFocus while focus sits anywhere on its chain - so with a word selected here
+        and another selected inside the frame, both would answer and both would open a
+        card. Only the deepest focused frame should.
+    -->
+    <p>En <span id="outer-word">bil</span> är ett fordon för transport.</p>
+
+    <iframe id="inner" src="http://localhost:3456/swedish-text.html"></iframe>
+</body>
+</html>

--- a/tests/e2e/test-pages/shadow-text.html
+++ b/tests/e2e/test-pages/shadow-text.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <title>Shadow DOM Test Page</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 12px; font-size: 18px; line-height: 1.4; }
+        div { margin: 8px 0; }
+    </style>
+</head>
+<body>
+    <h1>Text inside shadow roots</h1>
+
+    <!-- Text a reader sees and can select, but which lives in a shadow tree rather
+         than in the document. Sites built out of web components put most of their
+         text here, so the lookup gesture has to work on it. -->
+    <p>Light DOM, for comparison: En <span id="light-word">bil</span> är ett fordon.</p>
+
+    <div id="open-host"></div>
+    <div id="closed-host"></div>
+
+    <script>
+        const open = document.getElementById("open-host").attachShadow({ mode: "open" });
+        open.innerHTML = '<p style="font-family:Arial;font-size:18px">'
+            + 'Open shadow root: En <span id="shadow-word">bil</span> är ett fordon.</p>';
+
+        const closed = document.getElementById("closed-host").attachShadow({ mode: "closed" });
+        closed.innerHTML = '<p style="font-family:Arial;font-size:18px">'
+            + 'Closed shadow root: En <span id="closed-word">hund</span> är ett djur.</p>';
+    </script>
+</body>
+</html>

--- a/tests/e2e/test-pages/swedish-text.html
+++ b/tests/e2e/test-pages/swedish-text.html
@@ -44,6 +44,13 @@
         En <span id="test-word">bil</span> är ett fordon för transport. Många svenskar äger en bil.
         Stockholm är Sveriges största stad.
     </p>
+
+    <!-- A second word, several lines below the first. The gap is the point: a
+         Shift+click that extended the selection rather than naming one word would
+         swallow every word in between, and the trigger tests assert it does not. -->
+    <p>
+        En <span id="second-word">hund</span> är ett djur som många familjer har hemma.
+    </p>
 </body>
 </html>
 

--- a/tests/e2e/test-pages/swedish-text.html
+++ b/tests/e2e/test-pages/swedish-text.html
@@ -58,6 +58,7 @@
     <p>
         Ett <span id="split-word">h<em>u</em>nd</span> är också ett djur.
     </p>
+
 </body>
 </html>
 

--- a/tests/e2e/test-pages/swedish-text.html
+++ b/tests/e2e/test-pages/swedish-text.html
@@ -51,6 +51,13 @@
     <p>
         En <span id="second-word">hund</span> är ett djur som många familjer har hemma.
     </p>
+
+    <!-- A word the page has split across inline elements. It renders as one word and
+         a reader double-clicks it as one, but it is three text nodes - so naming the
+         word by the text node under the pointer alone would return a fragment. -->
+    <p>
+        Ett <span id="split-word">h<em>u</em>nd</span> är också ett djur.
+    </p>
 </body>
 </html>
 

--- a/tests/e2e/test-pages/word-boundaries.html
+++ b/tests/e2e/test-pages/word-boundaries.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <title>Word Boundaries Test Page</title>
+    <style>
+        /* Deliberately compact: every target has to sit inside the viewport, because
+           the caret APIs only answer for points a reader could actually click. */
+        body { font-family: Arial, sans-serif; padding: 12px; font-size: 18px; line-height: 1.4; }
+        p, div { margin: 6px 0; }
+    </style>
+</head>
+<body>
+    <h1>Word boundaries</h1>
+
+    <!-- A word the markup splits across inline elements. It renders as one word and a
+         reader double-clicks it as one, but it is three text nodes. -->
+    <p>Ett <span id="split-word">h<em>u</em>nd</span> är också ett djur.</p>
+
+    <!-- A line break between two words. It carries no text of its own, so eliding it
+         while flowing the surrounding text together would read this as "bilhund". -->
+    <p><span id="break-before">bil</span><br><span id="break-after">hund</span></p>
+
+    <!-- The same, with a nested block rather than a line break. -->
+    <div id="block-wrap"><span id="block-before">bil</span><div>x</div><span id="block-after">hund</span></div>
+
+    <!-- A linked word. Every trigger does something to a link, and none of it should
+         happen when the reader only meant to look the word up. -->
+    <p>En <a id="linked-word" href="https://example.com/">bil</a> till.</p>
+</body>
+</html>

--- a/tests/e2e/test-pages/word-boundaries.html
+++ b/tests/e2e/test-pages/word-boundaries.html
@@ -35,6 +35,10 @@
     <p>Ett <span id="hidden-attr">h<span hidden>ZZZ</span>und</span> till.</p>
     <p>Ett <span id="hidden-css">h<span style="display:none">ZZZ</span>und</span> till.</p>
 
+    <!-- An accessible SVG icon. Its <title> is a name for screen readers, not a word
+         on the page, so it must neither join the words either side nor be looked up. -->
+    <p><span id="svg-before">bil</span><svg id="svg-icon" width="12" height="12" role="img"><title>ikon</title><rect width="12" height="12" fill="#888"></rect></svg><span id="svg-after">hund</span></p>
+
     <!-- A linked word. Every trigger does something to a link, and none of it should
          happen when the reader only meant to look the word up. -->
     <p>En <a id="linked-word" href="https://example.com/">bil</a> till.</p>

--- a/tests/e2e/test-pages/word-boundaries.html
+++ b/tests/e2e/test-pages/word-boundaries.html
@@ -30,6 +30,11 @@
     <p><span id="icon-before">bil</span><img id="icon" src="data:image/gif;base64,R0lGODlhCgAKAIAAAP///wAAACH5BAEAAAAALAAAAAAKAAoAAAIIhI+py+0PYysAOw==" alt=""><span id="icon-after">hund</span></p>
     <p>Ett <span id="empty-wrap">h<span></span>und</span> till.</p>
 
+    <!-- Hidden elements render no box at all, so they separate nothing - not even the
+         one carrying text, whose text is not on the page either. -->
+    <p>Ett <span id="hidden-attr">h<span hidden>ZZZ</span>und</span> till.</p>
+    <p>Ett <span id="hidden-css">h<span style="display:none">ZZZ</span>und</span> till.</p>
+
     <!-- A linked word. Every trigger does something to a link, and none of it should
          happen when the reader only meant to look the word up. -->
     <p>En <a id="linked-word" href="https://example.com/">bil</a> till.</p>

--- a/tests/e2e/test-pages/word-boundaries.html
+++ b/tests/e2e/test-pages/word-boundaries.html
@@ -24,6 +24,12 @@
     <!-- The same, with a nested block rather than a line break. -->
     <div id="block-wrap"><span id="block-before">bil</span><div>x</div><span id="block-after">hund</span></div>
 
+    <!-- An icon between two words. It carries no text but takes up room, so the words
+         either side of it are two words. The second pair is the counter-case: an empty
+         wrapper renders nothing at all, and the word around it is still one word. -->
+    <p><span id="icon-before">bil</span><img id="icon" src="data:image/gif;base64,R0lGODlhCgAKAIAAAP///wAAACH5BAEAAAAALAAAAAAKAAoAAAIIhI+py+0PYysAOw==" alt=""><span id="icon-after">hund</span></p>
+    <p>Ett <span id="empty-wrap">h<span></span>und</span> till.</p>
+
     <!-- A linked word. Every trigger does something to a link, and none of it should
          happen when the reader only meant to look the word up. -->
     <p>En <a id="linked-word" href="https://example.com/">bil</a> till.</p>

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -255,6 +255,25 @@ test.describe("Lookup trigger", () => {
             await expect(page.locator(CARD_WORD)).toHaveText("hund");
         });
 
+    test("a hidden element should separate nothing", async ({ context, extensionId }) => {
+        // A hidden element renders no box, so it does not split the visible word -
+        // and its text is not on the page either, so it must not join it. Both are
+        // easy to get wrong in opposite directions: `display: none` fails every test
+        // for flowing inline, so it reads as a block unless it is skipped first.
+        //
+        // Under Shift, which is the branch that names the word by position.
+        await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+        const page = await context.newPage();
+        await openTestPage(page, BOUNDARIES_PAGE);
+
+        await ExtensionHelpers.triggerLookup(page, "#hidden-attr", { modifier: "Shift" });
+        await expect(page.locator(CARD_WORD)).toHaveText("hund");
+
+        await ExtensionHelpers.triggerLookup(page, "#hidden-css", { modifier: "Shift" });
+        await expect(page.locator(CARD_WORD)).toHaveText("hund");
+    });
+
     test("a trigger click should have the page's default suppressed", async ({ context }) => {
         // The click path used to return before suppressing the default whenever there
         // was no selection yet - which is exactly the first click of a double-click on

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -177,6 +177,85 @@ test.describe("Lookup trigger", () => {
         await expect(page.locator(CARD_WORD)).toHaveText("hund");
     });
 
+    test("a word split across inline elements should come back whole", async ({ context }) => {
+        // `h<em>u</em>nd` renders as one word and a reader double-clicks it as one,
+        // but it is three text nodes. Naming the word from the node under the pointer
+        // alone returns a fragment - "u" or "nd" - so where the browser was allowed
+        // to make the selection, its own is what the lookup uses.
+        const page = await context.newPage();
+        await openTestPage(page);
+
+        await ExtensionHelpers.triggerLookup(page, "#split-word");
+
+        await expect(page.locator(CARD_WORD)).toHaveText("hund");
+    });
+
+    test("a double-click should look a word up once, not twice",
+        async ({ context, extensionId }) => {
+            // A double-click arrives as click, click, dblclick, and the second click
+            // reached the lookup too - so one gesture made two dictionary requests
+            // and filed two identical history entries.
+            //
+            // Counted in history rather than in cards: each lookup dismisses the card
+            // before opening its own, so a duplicate leaves exactly one card behind
+            // and is invisible from the page.
+            await ExtensionHelpers.setLanguage(context, extensionId, "swe_swe");
+            await ExtensionHelpers.seedHistory(context, extensionId, { swe_swe: [] });
+
+            const page = await context.newPage();
+            await openTestPage(page);
+
+            await ExtensionHelpers.triggerLookup(page, "#test-word");
+            await expect(page.locator(CARD_WORD)).toHaveText("bil");
+            // Long enough for a second lookup to have been written.
+            await page.waitForTimeout(1500);
+
+            const stored = await ExtensionHelpers.getStoredValue(context, extensionId, "historyswe_swe");
+            const entries = JSON.parse(stored || "[]") as { word: string }[];
+
+            expect(entries.filter((entry) => entry.word === "bil")).toHaveLength(1);
+        });
+
+    test("Shift should not look up a selection left over from before the gesture",
+        async ({ context, extensionId }) => {
+            // Suppressing the mousedown default keeps an older selection alive, and
+            // the first click of a double-click would otherwise look *that* up -
+            // a card for a word the reader chose some time ago, and a history entry
+            // with it, on every Shift double-click.
+            // Counted in history, not in cards: the stale lookup's card is dismissed
+            // by the one that follows it, so the page looks right either way and only
+            // the reader's history remembers.
+            await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+            await ExtensionHelpers.setLanguage(context, extensionId, "swe_swe");
+            await ExtensionHelpers.seedHistory(context, extensionId, { swe_swe: [] });
+
+            const page = await context.newPage();
+            await openTestPage(page);
+
+            // A word selected before the gesture, and not the one about to be
+            // double-clicked.
+            await page.evaluate(() => {
+                const range = document.createRange();
+                range.selectNodeContents(document.querySelector("#test-word") as Node);
+                const selection = window.getSelection();
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+            });
+
+            await ExtensionHelpers.triggerLookup(page, "#second-word", { modifier: "Shift" });
+
+            await expect(page.locator(CARD_WORD)).toHaveText("hund");
+            // Past the grace period, so a click lookup that was never cancelled has
+            // had time to fire and be written.
+            await page.waitForTimeout(1500);
+
+            const stored = await ExtensionHelpers.getStoredValue(context, extensionId, "historyswe_swe");
+            const words = (JSON.parse(stored || "[]") as { word: string }[]).map((e) => e.word);
+
+            expect(words).toContain("hund");
+            expect(words).not.toContain("bil");
+        });
+
     test("a plain click should still dismiss the card", async ({ context, extensionId }) => {
         // The click listener does double duty - trigger and dismiss-on-click-out -
         // and only this notices if the trigger check swallows the dismissal.
@@ -221,6 +300,49 @@ test.describe("Lookup trigger", () => {
             }, MessageType.translateSelection);
 
             await expect(page.locator(CARD_WORD)).toHaveText("bil");
+        });
+
+    test("the keyboard command should open one card when a frame is focused",
+        async ({ context }) => {
+            // Both documents keep a selection and both report hasFocus - the top one
+            // because focus is on its chain, via the iframe. Without naming the
+            // deepest focused frame, both answer: two cards, two lookups, two history
+            // entries, from one keystroke.
+            const page = await context.newPage();
+            const worker = await backgroundWorker(context);
+
+            await page.goto("http://localhost:3456/framed-text.html");
+            await page.waitForLoadState("domcontentloaded");
+            await page.waitForTimeout(700);
+
+            // Select a word in the top document first, then one inside the frame -
+            // leaving the top document's selection alive but no longer focused.
+            await page.evaluate(() => {
+                const range = document.createRange();
+                range.selectNodeContents(document.querySelector("#outer-word") as Node);
+                const selection = window.getSelection();
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+            });
+
+            const frame = page.frameLocator("#inner");
+            await frame.locator("#second-word").click();
+            await page.frames()[1].evaluate(() => {
+                const range = document.createRange();
+                range.selectNodeContents(document.querySelector("#second-word") as Node);
+                const selection = window.getSelection();
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+            });
+
+            await worker.evaluate(async (method) => {
+                const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+                await chrome.tabs.sendMessage(tabs[0].id!, { method });
+            }, MessageType.translateSelection);
+
+            await expect(frame.locator(CARD_WORD)).toHaveText("hund");
+            // The top document, whose selection is stale, must have stayed quiet.
+            await expect(page.locator(CARD_HOST)).toHaveCount(0);
         });
 
     test("the keyboard command should do nothing with no selection", async ({ context, page }) => {

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -21,6 +21,8 @@ const TEST_PAGE = "http://localhost:3456/swedish-text.html";
 /** Markup that splits or runs words together, and a linked word. Kept compact and
  *  separate so every target stays inside the viewport. */
 const BOUNDARIES_PAGE = "http://localhost:3456/word-boundaries.html";
+/** Text inside shadow roots, as a page built out of web components keeps it. */
+const SHADOW_PAGE = "http://localhost:3456/shadow-text.html";
 
 /** Where the card's own text lives. Locators pierce the open shadow root. */
 const CARD = ".lexinTranslationContent";
@@ -281,6 +283,36 @@ test.describe("Lookup trigger", () => {
         await ExtensionHelpers.triggerLookup(page, "#hidden-css", { modifier: "Shift" });
         await expect(page.locator(CARD_WORD)).toHaveText("hund");
     });
+
+    test("a word inside a web component should be found by position",
+        async ({ context, extensionId }) => {
+            // Neither caret API descends into a shadow tree unasked, so naming a word
+            // by position used to fail outright on any page built out of web
+            // components - which is most text on a lot of sites.
+            //
+            // Under Shift, the branch with no browser selection to fall back on and
+            // therefore the one that has to reach in.
+            await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+            const page = await context.newPage();
+            await openTestPage(page, SHADOW_PAGE);
+
+            await ExtensionHelpers.triggerLookup(page, "#shadow-word", { modifier: "Shift" });
+
+            await expect(page.locator(CARD_WORD)).toHaveText("bil");
+        });
+
+    test("a word inside a web component should still work on the default trigger",
+        async ({ context }) => {
+            // Alt reads the browser's own selection first, which has always pierced
+            // shadow roots. Here to keep it that way.
+            const page = await context.newPage();
+            await openTestPage(page, SHADOW_PAGE);
+
+            await ExtensionHelpers.triggerLookup(page, "#shadow-word");
+
+            await expect(page.locator(CARD_WORD)).toHaveText("bil");
+        });
 
     test("a trigger click should have the page's default suppressed", async ({ context }) => {
         // The click path used to return before suppressing the default whenever there

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -231,6 +231,30 @@ test.describe("Lookup trigger", () => {
             await expect(page.locator(CARD_WORD)).toHaveText("hund");
         });
 
+    test("an icon between words should separate them, an empty wrapper should not",
+        async ({ context, extensionId }) => {
+            // An <img> carries no text but takes up room, so `bil<img>hund` is two
+            // words - collecting it as `bilhund` would look up a word that is not on
+            // the page. An empty <span> renders nothing, so the word around it is
+            // still one word, and treating every textless element as a separator
+            // would break it.
+            //
+            // Under Shift, which is the branch that names the word by position.
+            await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+            const page = await context.newPage();
+            await openTestPage(page, BOUNDARIES_PAGE);
+
+            await ExtensionHelpers.triggerLookup(page, "#icon-before", { modifier: "Shift" });
+            await expect(page.locator(CARD_WORD)).toHaveText("bil");
+
+            await ExtensionHelpers.triggerLookup(page, "#icon-after", { modifier: "Shift" });
+            await expect(page.locator(CARD_WORD)).toHaveText("hund");
+
+            await ExtensionHelpers.triggerLookup(page, "#empty-wrap", { modifier: "Shift" });
+            await expect(page.locator(CARD_WORD)).toHaveText("hund");
+        });
+
     test("a trigger click should have the page's default suppressed", async ({ context }) => {
         // The click path used to return before suppressing the default whenever there
         // was no selection yet - which is exactly the first click of a double-click on

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -180,8 +180,7 @@ test.describe("Lookup trigger", () => {
     test("a word split across inline elements should come back whole", async ({ context }) => {
         // `h<em>u</em>nd` renders as one word and a reader double-clicks it as one,
         // but it is three text nodes. Naming the word from the node under the pointer
-        // alone returns a fragment - "u" or "nd" - so where the browser was allowed
-        // to make the selection, its own is what the lookup uses.
+        // alone returns a fragment - "u" or "nd".
         const page = await context.newPage();
         await openTestPage(page);
 
@@ -189,6 +188,76 @@ test.describe("Lookup trigger", () => {
 
         await expect(page.locator(CARD_WORD)).toHaveText("hund");
     });
+
+    test("a split word should come back whole under Shift too", async ({ context, extensionId }) => {
+        // Shift takes the other branch: its selection is suppressed, so the browser's
+        // is not there to fall back on and wordAtPoint has to name the word by
+        // itself. Pages split words whenever they emphasise or highlight part of one,
+        // which is most words on a page of search results.
+        await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+        const page = await context.newPage();
+        await openTestPage(page);
+
+        await ExtensionHelpers.triggerLookup(page, "#split-word", { modifier: "Shift" });
+
+        await expect(page.locator(CARD_WORD)).toHaveText("hund");
+    });
+
+    test("Shift should ignore a selection the reader clicked away from",
+        async ({ context, extensionId }) => {
+            // The other side of the select-then-click flow, and the precise reason the
+            // click path checks where the click landed. With a selection lying around,
+            // a Shift click elsewhere is the first half of a double-click aimed at
+            // another word - looking the old selection up would open a card for a word
+            // the reader chose some time ago and file a history entry for it.
+            //
+            // A single click rather than a double: it isolates the click path, and
+            // the card it wrongly opens is not dismissed a moment later by the
+            // double-click's own.
+            await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+            const page = await context.newPage();
+            await openTestPage(page);
+
+            await page.evaluate(() => {
+                const range = document.createRange();
+                range.selectNodeContents(document.querySelector("#test-word") as Node);
+                const selection = window.getSelection();
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+            });
+
+            await ExtensionHelpers.triggerLookup(page, "#second-word",
+                { modifier: "Shift", gesture: "click" });
+
+            await page.waitForTimeout(1000);
+            await expect(page.locator(CARD_HOST)).toHaveCount(0);
+        });
+
+    test("Shift should still look up a selection the reader clicks on",
+        async ({ context, extensionId }) => {
+            // The select-then-click flow, which the help page offers whatever the
+            // trigger. Clicking *on* the selection is what separates it from the
+            // first half of a double-click aimed elsewhere, so it has to keep working.
+            await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+            const page = await context.newPage();
+            await openTestPage(page);
+
+            await page.evaluate(() => {
+                const range = document.createRange();
+                range.selectNodeContents(document.querySelector("#test-word") as Node);
+                const selection = window.getSelection();
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+            });
+
+            await ExtensionHelpers.triggerLookup(page, "#test-word",
+                { modifier: "Shift", gesture: "click" });
+
+            await expect(page.locator(CARD_WORD)).toHaveText("bil");
+        });
 
     test("a double-click should look a word up once, not twice",
         async ({ context, extensionId }) => {
@@ -199,6 +268,11 @@ test.describe("Lookup trigger", () => {
             // Counted in history rather than in cards: each lookup dismisses the card
             // before opening its own, so a duplicate leaves exactly one card behind
             // and is invisible from the page.
+            //
+            // History is the only witness, and an imperfect one - two writes this
+            // close together can read the same store and one overwrite the other, so
+            // a duplicate is occasionally undercounted. It never overcounts, so a
+            // failure here is always real.
             await ExtensionHelpers.setLanguage(context, extensionId, "swe_swe");
             await ExtensionHelpers.seedHistory(context, extensionId, { swe_swe: [] });
 
@@ -216,24 +290,23 @@ test.describe("Lookup trigger", () => {
             expect(entries.filter((entry) => entry.word === "bil")).toHaveLength(1);
         });
 
-    test("Shift should not look up a selection left over from before the gesture",
+    test("Shift should look up the pointed word with a selection lying around",
         async ({ context, extensionId }) => {
-            // Suppressing the mousedown default keeps an older selection alive, and
-            // the first click of a double-click would otherwise look *that* up -
-            // a card for a word the reader chose some time ago, and a history entry
-            // with it, on every Shift double-click.
-            // Counted in history, not in cards: the stale lookup's card is dismissed
-            // by the one that follows it, so the page looks right either way and only
-            // the reader's history remembers.
+            // End to end for the case the click gate exists to protect: a selection
+            // from earlier, and a double-click somewhere else. The word that wins is
+            // the one under the pointer.
+            //
+            // Only the final card is asserted, deliberately. A spurious lookup here
+            // would be dismissed a moment later by the double-click's own card, and
+            // history cannot see it either - two lookups this close together
+            // read-modify-write the same store and one can overwrite the other. The
+            // gate itself is pinned by the single-click test above, where a wrong
+            // lookup has nothing to hide behind.
             await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
-            await ExtensionHelpers.setLanguage(context, extensionId, "swe_swe");
-            await ExtensionHelpers.seedHistory(context, extensionId, { swe_swe: [] });
 
             const page = await context.newPage();
             await openTestPage(page);
 
-            // A word selected before the gesture, and not the one about to be
-            // double-clicked.
             await page.evaluate(() => {
                 const range = document.createRange();
                 range.selectNodeContents(document.querySelector("#test-word") as Node);
@@ -245,15 +318,6 @@ test.describe("Lookup trigger", () => {
             await ExtensionHelpers.triggerLookup(page, "#second-word", { modifier: "Shift" });
 
             await expect(page.locator(CARD_WORD)).toHaveText("hund");
-            // Past the grace period, so a click lookup that was never cancelled has
-            // had time to fire and be written.
-            await page.waitForTimeout(1500);
-
-            const stored = await ExtensionHelpers.getStoredValue(context, extensionId, "historyswe_swe");
-            const words = (JSON.parse(stored || "[]") as { word: string }[]).map((e) => e.word);
-
-            expect(words).toContain("hund");
-            expect(words).not.toContain("bil");
         });
 
     test("a plain click should still dismiss the card", async ({ context, extensionId }) => {

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -1,0 +1,252 @@
+import { test, expect, ExtensionHelpers } from "./fixtures";
+import type { BrowserContext, Page, Worker } from "@playwright/test";
+import MessageType from "../../src/scripts/messaging/MessageType";
+
+/**
+ * The configurable lookup trigger (issue #17), and what these tests cannot prove.
+ *
+ * Playwright drives Chrome over CDP, which injects input *below* the layer where
+ * ChromeOS's Ash and GNOME's Mutter take Alt+click for themselves. The bug this
+ * feature exists to fix - a reader on those desktops unable to look a word up at all
+ * - is therefore not reproducible here, on any platform.
+ *
+ * What is testable, and is: that the trigger is configurable, that a non-default
+ * modifier works and the default then does not, that a change reaches a tab that is
+ * already open, that dismissal is unaffected, that Shift does not drag the selection
+ * along behind it, and that the copy tells the reader the truth. The interception
+ * itself is verified by hand, on the platform - see docs/adr/0005.
+ */
+
+const TEST_PAGE = "http://localhost:3456/swedish-text.html";
+
+/** Where the card's own text lives. Locators pierce the open shadow root. */
+const CARD = ".lexinTranslationContent";
+const CARD_HOST = ".lexinExtensionMainContainer";
+
+/**
+ * Just the word the card was opened on.
+ *
+ * Not `.lexinCardWord`, which also wraps the flag and the "· sv" language pair -
+ * these tests assert the word is one word and nothing else, so the extra text would
+ * hide exactly the failure they exist to catch.
+ */
+const CARD_WORD = ".lexinCardWord > span:not(.lexinCardPair)";
+
+/**
+ * Pick a segmented option by its stored value rather than its label.
+ *
+ * The modifier options are named for the platform - a Mac says Option, not Alt - so
+ * filtering on text would make these tests pass or fail by operating system.
+ */
+async function pickSegValue(page: Page, groupId: string, value: string) {
+    await page.locator(`#${groupId} .lxSegOption:has(input[value='${value}'])`).click();
+}
+
+/**
+ * The extension's service worker, woken if Chrome has let it go to sleep.
+ *
+ * serviceWorkers() is empty for a dormant MV3 worker, which is ordinary partway
+ * through a suite - the same wait the extensionId fixture does.
+ */
+async function backgroundWorker(context: BrowserContext): Promise<Worker> {
+    return context.serviceWorkers()[0] ?? await context.waitForEvent("serviceworker");
+}
+
+async function openTestPage(page: Page): Promise<void> {
+    await page.goto(TEST_PAGE);
+    await page.waitForLoadState("domcontentloaded");
+    // The content script is injected at document_end and warms its cache after that.
+    await page.waitForTimeout(500);
+}
+
+test.describe("Lookup trigger", () => {
+
+    test("options page should persist a chosen modifier", async ({ context, extensionId, optionsPage }) => {
+        const page = await optionsPage();
+
+        // Alt is the default, and every existing reader is on it.
+        await expect(page.locator("#triggerModifier input[value='alt']")).toBeChecked();
+
+        await pickSegValue(page, "triggerModifier", "shift");
+        await expect(page.locator(".lxToast")).toHaveText("Options saved");
+
+        await page.reload();
+        await expect(page.locator("#triggerModifier input[value='shift']")).toBeChecked();
+        expect(await ExtensionHelpers.getStoredValue(context, extensionId, "triggerModifier"))
+            .toBe("shift");
+    });
+
+    test("a chosen modifier should open a card where the default no longer does",
+        async ({ context, extensionId }) => {
+            // The negative half is the point: without it, a test could pass while the
+            // setting did nothing and Alt still worked.
+            await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+            const page = await context.newPage();
+            await openTestPage(page);
+            await ExtensionHelpers.triggerLookup(page, "#test-word", { modifier: "Shift" });
+            await expect(page.locator(CARD)).toBeVisible();
+
+            const other = await context.newPage();
+            await openTestPage(other);
+            await ExtensionHelpers.triggerLookup(other, "#test-word", { modifier: "Alt" });
+            await expect(other.locator(CARD_HOST)).toHaveCount(0);
+        });
+
+    test("a change should reach a tab that is already open", async ({ context, extensionId, optionsPage }) => {
+        // The reason the extension has a storage subscription at all. A reader
+        // changes the modifier precisely because the current one is intercepted, so
+        // the page they were reading can never open a card to re-read it lazily.
+        const page = await context.newPage();
+        await openTestPage(page);
+
+        const options = await optionsPage();
+        await pickSegValue(options, "triggerModifier", "shift");
+        await expect(options.locator(".lxToast")).toHaveText("Options saved");
+
+        // Deliberately no reload of `page`.
+        await page.bringToFront();
+        await ExtensionHelpers.triggerLookup(page, "#test-word", { modifier: "Shift" });
+        await expect(page.locator(CARD)).toBeVisible();
+    });
+
+    test("Shift should look up the second word, not the span up to it",
+        async ({ context, extensionId }) => {
+            // Half of the reported defect. Shift+click means "extend the selection
+            // from the existing anchor", so after the first lookup the anchor sat on
+            // "bil" and the second click selected everything up to "hund".
+            //
+            // What fixes *this* half is that the double-click path names its word by
+            // position rather than by reading the selection - see the dblclick
+            // handler. The other half, the selection visibly growing across the page,
+            // is the test below.
+            await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+            const page = await context.newPage();
+            await openTestPage(page);
+
+            await ExtensionHelpers.triggerLookup(page, "#test-word", { modifier: "Shift" });
+            await expect(page.locator(CARD_WORD)).toHaveText("bil");
+
+            await ExtensionHelpers.triggerLookup(page, "#second-word", { modifier: "Shift" });
+            const heading = await page.locator(CARD_WORD).textContent();
+
+            expect(heading?.trim()).toBe("hund");
+            // Whatever it is, it is one word and not a span of the page.
+            expect(heading!.trim().split(/\s+/)).toHaveLength(1);
+        });
+
+    test("Shift should not grow the page's own selection", async ({ context, extensionId }) => {
+        // The other half, and the one the reader actually sees: even with the right
+        // word looked up, Shift+click left the page itself selected from the first
+        // word to the last, highlighted in blue across several lines.
+        //
+        // This is what the mousedown preventDefault is for. Remove it and this fails
+        // while the test above still passes, which is why they are separate.
+        await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+        const page = await context.newPage();
+        await openTestPage(page);
+
+        await ExtensionHelpers.triggerLookup(page, "#test-word", { modifier: "Shift" });
+        await ExtensionHelpers.triggerLookup(page, "#second-word", { modifier: "Shift" });
+
+        const selected = await page.evaluate(() => window.getSelection()?.toString() ?? "");
+
+        // The prose between the two words runs to well over a hundred characters, so
+        // an extended selection is unmistakable; a word is not.
+        expect(selected.length).toBeLessThan(20);
+        expect(selected).not.toContain("fordon");
+    });
+
+    test("position should beat a stale selection", async ({ context }) => {
+        // Independent of Shift: a double-click means "the word I am pointing at",
+        // whatever the browser happened to have selected beforehand.
+        const page = await context.newPage();
+        await openTestPage(page);
+
+        await page.evaluate(() => {
+            const range = document.createRange();
+            range.selectNodeContents(document.querySelector("#test-word") as Node);
+            const selection = window.getSelection();
+            selection?.removeAllRanges();
+            selection?.addRange(range);
+        });
+
+        await ExtensionHelpers.triggerLookup(page, "#second-word");
+        await expect(page.locator(CARD_WORD)).toHaveText("hund");
+    });
+
+    test("a plain click should still dismiss the card", async ({ context, extensionId }) => {
+        // The click listener does double duty - trigger and dismiss-on-click-out -
+        // and only this notices if the trigger check swallows the dismissal.
+        await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+        const page = await context.newPage();
+        await openTestPage(page);
+        await ExtensionHelpers.triggerLookup(page, "#test-word", { modifier: "Shift" });
+        await expect(page.locator(CARD)).toBeVisible();
+
+        await page.mouse.click(5, 5);
+        await expect(page.locator(CARD_HOST)).toHaveCount(0);
+    });
+
+    test("the keyboard command should be declared and should translate a selection",
+        async ({ context, page }) => {
+            const worker = await backgroundWorker(context);
+
+            const commands = await worker.evaluate(async () => {
+                return await chrome.commands.getAll();
+            });
+            const translate = commands.find((c: any) => c.name === "translate-selection");
+            expect(translate).toBeTruthy();
+            expect(translate.description).toBe("Translate the selected word");
+
+            await openTestPage(page);
+            await page.evaluate(() => {
+                const range = document.createRange();
+                range.selectNodeContents(document.querySelector("#test-word") as Node);
+                const selection = window.getSelection();
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+            });
+
+            // Chrome's own dispatch of the keystroke to onCommand is the one link
+            // this cannot cover: page.keyboard.press goes to the renderer, and a
+            // browser-level extension shortcut never reaches it. Everything from the
+            // worker's handler onwards is exercised here.
+            await worker.evaluate(async (method) => {
+                const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+                await chrome.tabs.sendMessage(tabs[0].id!, { method });
+            }, MessageType.translateSelection);
+
+            await expect(page.locator(CARD_WORD)).toHaveText("bil");
+        });
+
+    test("the keyboard command should do nothing with no selection", async ({ context, page }) => {
+        // A panel opening on a keystroke that found no word is a surprise, not a
+        // help - and on a chrome:// page no frame answers at all.
+        const worker = await backgroundWorker(context);
+        await openTestPage(page);
+
+        await worker.evaluate(async (method) => {
+            const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+            await chrome.tabs.sendMessage(tabs[0].id!, { method });
+        }, MessageType.translateSelection);
+
+        await page.waitForTimeout(500);
+        await expect(page.locator(CARD_HOST)).toHaveCount(0);
+    });
+
+    test("the copy should name the modifier the reader chose", async ({ context, extensionId, popupPage }) => {
+        await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+        const help = await context.newPage();
+        await help.goto(`chrome-extension://${extensionId}/html/help.html`);
+        await expect(help.locator("#stepDoubleClick")).toHaveText("Shift + double-click a word");
+        await expect(help.locator("#stepClick")).toHaveText("Select, then Shift + click");
+
+        const popup = await popupPage();
+        await expect(popup.locator("#translation")).toContainText("Shift + double-click a word");
+    });
+});

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -253,6 +253,14 @@ test.describe("Lookup trigger", () => {
 
             await ExtensionHelpers.triggerLookup(page, "#empty-wrap", { modifier: "Shift" });
             await expect(page.locator(CARD_WORD)).toHaveText("hund");
+
+            // An accessible SVG icon has text - its <title> - and none of it is on
+            // the page. Reading textContent would flow this as "bilikonhund".
+            await ExtensionHelpers.triggerLookup(page, "#svg-before", { modifier: "Shift" });
+            await expect(page.locator(CARD_WORD)).toHaveText("bil");
+
+            await ExtensionHelpers.triggerLookup(page, "#svg-after", { modifier: "Shift" });
+            await expect(page.locator(CARD_WORD)).toHaveText("hund");
         });
 
     test("a hidden element should separate nothing", async ({ context, extensionId }) => {

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -18,6 +18,9 @@ import MessageType from "../../src/scripts/messaging/MessageType";
  */
 
 const TEST_PAGE = "http://localhost:3456/swedish-text.html";
+/** Markup that splits or runs words together, and a linked word. Kept compact and
+ *  separate so every target stays inside the viewport. */
+const BOUNDARIES_PAGE = "http://localhost:3456/word-boundaries.html";
 
 /** Where the card's own text lives. Locators pierce the open shadow root. */
 const CARD = ".lexinTranslationContent";
@@ -52,8 +55,8 @@ async function backgroundWorker(context: BrowserContext): Promise<Worker> {
     return context.serviceWorkers()[0] ?? await context.waitForEvent("serviceworker");
 }
 
-async function openTestPage(page: Page): Promise<void> {
-    await page.goto(TEST_PAGE);
+async function openTestPage(page: Page, url: string = TEST_PAGE): Promise<void> {
+    await page.goto(url);
     await page.waitForLoadState("domcontentloaded");
     // The content script is injected at document_end and warms its cache after that.
     await page.waitForTimeout(500);
@@ -182,7 +185,7 @@ test.describe("Lookup trigger", () => {
         // but it is three text nodes. Naming the word from the node under the pointer
         // alone returns a fragment - "u" or "nd".
         const page = await context.newPage();
-        await openTestPage(page);
+        await openTestPage(page, BOUNDARIES_PAGE);
 
         await ExtensionHelpers.triggerLookup(page, "#split-word");
 
@@ -202,6 +205,57 @@ test.describe("Lookup trigger", () => {
         await ExtensionHelpers.triggerLookup(page, "#split-word", { modifier: "Shift" });
 
         await expect(page.locator(CARD_WORD)).toHaveText("hund");
+    });
+
+    test("markup that runs words together should still name one word",
+        async ({ context, extensionId }) => {
+            // A line break and a nested block both carry no text of their own.
+            // Eliding them while flowing the surrounding text together reads
+            // `bil<br>hund` as `bilhund` and looks that up - a word not on the page.
+            //
+            // Under Shift, deliberately: that is the branch which names the word by
+            // position. Alt would defer to the browser's own selection and never
+            // reach the code under test.
+            await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+
+            const page = await context.newPage();
+            await openTestPage(page, BOUNDARIES_PAGE);
+
+            await ExtensionHelpers.triggerLookup(page, "#break-before", { modifier: "Shift" });
+            await expect(page.locator(CARD_WORD)).toHaveText("bil");
+
+            await ExtensionHelpers.triggerLookup(page, "#break-after", { modifier: "Shift" });
+            await expect(page.locator(CARD_WORD)).toHaveText("hund");
+
+            await ExtensionHelpers.triggerLookup(page, "#block-after", { modifier: "Shift" });
+            await expect(page.locator(CARD_WORD)).toHaveText("hund");
+        });
+
+    test("a trigger click should have the page's default suppressed", async ({ context }) => {
+        // The click path used to return before suppressing the default whenever there
+        // was no selection yet - which is exactly the first click of a double-click on
+        // a word. Every trigger does something to a link on that click: Ctrl+click
+        // opens a background tab, Alt+click downloads, Shift+click opens a window.
+        //
+        // Asserted on the event rather than on the consequence, because the
+        // consequence differs by modifier and by platform, and two of the three are
+        // not observable here at all. defaultPrevented is the fix itself.
+        const page = await context.newPage();
+        await openTestPage(page, BOUNDARIES_PAGE);
+
+        // Registered after the content script's, so it sees the flag as the browser
+        // will when it decides what to do next.
+        await page.evaluate(() => {
+            (window as any).__prevented = [];
+            document.addEventListener("click", (e) => {
+                (window as any).__prevented.push(e.defaultPrevented);
+            });
+        });
+
+        // A single click with nothing selected: the case that used to slip through.
+        await ExtensionHelpers.triggerLookup(page, "#break-after", { gesture: "click" });
+
+        expect(await page.evaluate(() => (window as any).__prevented)).toEqual([true]);
     });
 
     test("Shift should ignore a selection the reader clicked away from",

--- a/tests/unit/BackgroundWorkerTests.ts
+++ b/tests/unit/BackgroundWorkerTests.ts
@@ -1,10 +1,13 @@
 import BackgroundWorker from "../../src/scripts/worker/BackgroundWorker.js";
+import { TRANSLATE_SELECTION_COMMAND } from "../../src/scripts/common/LookupTrigger.js";
 import TranslationDirection from "../../src/scripts/dictionary/TranslationDirection.js";
+import MessageType from "../../src/scripts/messaging/MessageType.js";
 import {
     FakeHistoryManager,
     FakeTranslationManager,
     FakeMessageHandlers,
-    FakeAudioPlayer
+    FakeAudioPlayer,
+    FakeMessageBus
 } from "./util/fakes.js";
 
 describe("BackgroundWorker", () => {
@@ -13,14 +16,32 @@ describe("BackgroundWorker", () => {
     let fakeTranslationManager: FakeTranslationManager;
     let fakeMessageHandlers: FakeMessageHandlers;
     let fakeAudioPlayer: FakeAudioPlayer;
+    let fakeMessageBus: FakeMessageBus;
 
     beforeEach(() => {
         fakeHistoryManager = new FakeHistoryManager();
         fakeTranslationManager = new FakeTranslationManager();
         fakeMessageHandlers = new FakeMessageHandlers();
         fakeAudioPlayer = new FakeAudioPlayer();
+        fakeMessageBus = new FakeMessageBus();
         backgroundWorker = new BackgroundWorker(fakeHistoryManager, fakeTranslationManager, fakeMessageHandlers,
-            fakeAudioPlayer);
+            fakeAudioPlayer, fakeMessageBus);
+    });
+
+    describe("translateSelection", () => {
+        it("should ask the active tab to look up its selection", async () => {
+            await backgroundWorker.translateSelection();
+            expect(fakeMessageBus.sentToActiveTab).toEqual([MessageType.translateSelection]);
+        });
+
+        it("should answer the keyboard shortcut", async () => {
+            // Chrome delivers a shortcut to the worker and nowhere else, so this
+            // registration is the only route a keystroke has into the extension.
+            backgroundWorker.initialize();
+            fakeMessageBus.pressCommand(TRANSLATE_SELECTION_COMMAND);
+
+            expect(fakeMessageBus.sentToActiveTab).toEqual([MessageType.translateSelection]);
+        });
     });
 
     describe("getTranslation", () => {

--- a/tests/unit/LookupTriggerTests.ts
+++ b/tests/unit/LookupTriggerTests.ts
@@ -1,0 +1,129 @@
+import {
+    availableModifiers,
+    gestureLabel,
+    isTriggerModifier,
+    matchesTrigger,
+    modifierLabel,
+    TRIGGER_MODIFIERS,
+    TriggerModifier
+} from "../../src/scripts/common/LookupTrigger.js";
+
+/** A MouseEvent as far as matchesTrigger is concerned, with only the flags set. */
+function flags(down: Partial<Record<"alt" | "ctrl" | "shift" | "meta", boolean>>) {
+    return {
+        altKey: !!down.alt,
+        ctrlKey: !!down.ctrl,
+        shiftKey: !!down.shift,
+        metaKey: !!down.meta
+    };
+}
+
+/** An event that reports only through getModifierState, with no flat flags at all. */
+function stateOnly(...keys: string[]) {
+    return { getModifierState: (key: string) => keys.indexOf(key) !== -1 };
+}
+
+describe("LookupTrigger", () => {
+
+    describe("matchesTrigger", () => {
+        it("should match a modifier held on its own", () => {
+            expect(matchesTrigger(flags({ alt: true }), "alt")).toBe(true);
+            expect(matchesTrigger(flags({ ctrl: true }), "ctrl")).toBe(true);
+            expect(matchesTrigger(flags({ shift: true }), "shift")).toBe(true);
+        });
+
+        it("should not match a modifier that is not held", () => {
+            expect(matchesTrigger(flags({}), "alt")).toBe(false);
+            expect(matchesTrigger(flags({ shift: true }), "alt")).toBe(false);
+            expect(matchesTrigger(flags({ alt: true }), "ctrl")).toBe(false);
+        });
+
+        it("should read getModifierState when the event carries no flags", () => {
+            // The flat flags are the legacy API. An event that only implements the
+            // documented one still has to work.
+            expect(matchesTrigger(stateOnly("Alt"), "alt")).toBe(true);
+            expect(matchesTrigger(stateOnly("Control"), "ctrl")).toBe(true);
+            expect(matchesTrigger(stateOnly("Shift"), "shift")).toBe(true);
+            expect(matchesTrigger(stateOnly("Alt"), "shift")).toBe(false);
+        });
+
+        it("should tolerate an event with no getModifierState at all", () => {
+            expect(matchesTrigger({ altKey: true }, "alt")).toBe(true);
+            expect(matchesTrigger({}, "alt")).toBe(false);
+        });
+
+        it("should not match when a second modifier is also held", () => {
+            // Exclusivity, and a deliberate change from the Alt-only behaviour:
+            // a permissive match would fire Ctrl+Shift+click for a Ctrl reader and a
+            // Shift reader alike, and compound chords are where browsers and pages
+            // put meanings of their own.
+            for (const modifier of TRIGGER_MODIFIERS) {
+                for (const other of TRIGGER_MODIFIERS) {
+                    if (other === modifier) { continue; }
+                    const both = flags({ [modifier]: true, [other]: true });
+                    expect(matchesTrigger(both, modifier)).toBe(false);
+                }
+            }
+        });
+
+        it("should not match when Meta is held", () => {
+            // Cmd+click already opens a link in a new tab. Firing as well would do both.
+            expect(matchesTrigger(flags({ alt: true, meta: true }), "alt")).toBe(false);
+            expect(matchesTrigger(stateOnly("Shift", "Meta"), "shift")).toBe(false);
+        });
+    });
+
+    describe("isTriggerModifier", () => {
+        it("should accept every modifier the setting can hold", () => {
+            TRIGGER_MODIFIERS.forEach((modifier) => {
+                expect(isTriggerModifier(modifier)).toBe(true);
+            });
+        });
+
+        it("should reject anything else", () => {
+            expect(isTriggerModifier("meta")).toBe(false);
+            expect(isTriggerModifier("")).toBe(false);
+            expect(isTriggerModifier(null)).toBe(false);
+        });
+    });
+
+    describe("availableModifiers", () => {
+        it("should offer all three away from a Mac", () => {
+            expect(availableModifiers(false)).toEqual(["alt", "ctrl", "shift"]);
+        });
+
+        it("should not offer Ctrl on a Mac", () => {
+            // macOS defines Ctrl+click as the secondary click, so Chrome raises
+            // contextmenu off the mousedown and never fires the click. The gesture
+            // cannot work there, and offering it would be offering a dead option.
+            expect(availableModifiers(true)).toEqual(["alt", "shift"]);
+        });
+    });
+
+    describe("labels", () => {
+        it("should name the keys as the platform engraves them", () => {
+            expect(modifierLabel("alt", false)).toBe("Alt");
+            expect(modifierLabel("ctrl", false)).toBe("Ctrl");
+            expect(modifierLabel("shift", false)).toBe("Shift");
+
+            expect(modifierLabel("alt", true)).toBe("Option");
+            expect(modifierLabel("ctrl", true)).toBe("Control");
+            expect(modifierLabel("shift", true)).toBe("Shift");
+        });
+
+        it("should spell out the whole gesture", () => {
+            expect(gestureLabel("alt", "double-click", false)).toBe("Alt + double-click");
+            expect(gestureLabel("alt", "click", true)).toBe("Option + click");
+            expect(gestureLabel("shift", "double-click", true)).toBe("Shift + double-click");
+        });
+
+        it("should have a label for every modifier it offers", () => {
+            // A modifier added to the list without a label would render as a blank
+            // option on the Options page.
+            TRIGGER_MODIFIERS.forEach((modifier: TriggerModifier) => {
+                expect(modifierLabel(modifier, false)).toBeTruthy();
+                expect(modifierLabel(modifier, true)).toBeTruthy();
+            });
+        });
+    });
+});

--- a/tests/unit/ManifestTests.ts
+++ b/tests/unit/ManifestTests.ts
@@ -27,6 +27,26 @@ describe("manifest permissions", () => {
         expect(manifest.permissions).not.toContain("tabs");
     });
 
+    it("should declare the translate-selection keyboard shortcut", () => {
+        // A command is a manifest key, not a permission: it adds nothing to the list
+        // above and shows the reader no warning at install. Nobody should "fix" the
+        // permissions to match this.
+        //
+        // The shortcut is the one trigger no desktop can take for itself, which is
+        // why it exists - ChromeOS and GNOME both intercept Alt+click before the page
+        // is sent anything. Chrome owns the binding, at chrome://extensions/shortcuts.
+        expect(Object.keys(manifest.commands)).toEqual(["translate-selection"]);
+
+        const command = manifest.commands["translate-selection"];
+        // Without a description Chrome shows a blank row in its shortcuts UI, and
+        // the reader has no way to tell what they are rebinding.
+        expect(command.description).toBeTruthy();
+        // Not global: the shortcut should only fire while Chrome is focused. A global
+        // one would be competing with the whole desktop for a chord, which is the
+        // class of problem this feature exists to get out of.
+        expect(command).not.toHaveProperty("global");
+    });
+
     it("should not request any host permission", () => {
         // host_permissions buys an extension one thing here: a CORS bypass for the
         // dictionary lookups. Neither service needs it - both answer with

--- a/tests/unit/SettingsTests.ts
+++ b/tests/unit/SettingsTests.ts
@@ -7,7 +7,9 @@ describe("Settings", () => {
 
     beforeEach(() => {
         storage = new FakeAsyncSettingsStorage();
-        settings = new Settings(storage);
+        // Pinned off a Mac, so the suite reads the same on a developer's laptop as it
+        // does on the Linux box in CI. The Mac branch is tested explicitly below.
+        settings = new Settings(storage, () => false);
     });
 
     describe("recordHistory", () => {
@@ -30,6 +32,43 @@ describe("Settings", () => {
             // dropping lookups is the worse failure.
             await storage.setItem("recordHistory", "maybe");
             expect(await settings.getRecordHistory()).toBe(true);
+        });
+    });
+
+    describe("triggerModifier", () => {
+        it("should default to alt", async () => {
+            // Every existing reader looks words up with Alt. The setting exists for
+            // the desktops that take Alt for themselves, not to move anyone else.
+            expect(await settings.getTriggerModifier()).toBe("alt");
+        });
+
+        it("should round-trip every modifier", async () => {
+            await settings.setTriggerModifier("shift");
+            expect(await settings.getTriggerModifier()).toBe("shift");
+
+            await settings.setTriggerModifier("ctrl");
+            expect(await settings.getTriggerModifier()).toBe("ctrl");
+
+            await settings.setTriggerModifier("alt");
+            expect(await settings.getTriggerModifier()).toBe("alt");
+        });
+
+        it("should treat anything it does not understand as alt", async () => {
+            // A value written by a newer version, or a corrupted store. Alt is at
+            // least a gesture the reader can perform.
+            await storage.setItem("triggerModifier", "hyper");
+            expect(await settings.getTriggerModifier()).toBe("alt");
+        });
+
+        it("should fall back to alt when the platform cannot deliver the stored key", async () => {
+            // Ctrl+click is the secondary click on a Mac, so the gesture never fires
+            // there. Honouring the stored value would leave the reader with no way to
+            // look a word up at all; Alt at least works.
+            const onAMac = new Settings(storage, () => true);
+            await storage.setItem("triggerModifier", "ctrl");
+
+            expect(await onAMac.getTriggerModifier()).toBe("alt");
+            expect(await settings.getTriggerModifier()).toBe("ctrl");
         });
     });
 });

--- a/tests/unit/WordAtPointTests.ts
+++ b/tests/unit/WordAtPointTests.ts
@@ -1,0 +1,50 @@
+import { wordAtOffset } from "../../src/scripts/content/WordAtPoint.js";
+
+describe("WordAtPoint", () => {
+
+    describe("wordAtOffset", () => {
+        it("should name the word the caret sits inside", () => {
+            const text = "en bil kör";
+            expect(wordAtOffset(text, 4)).toBe("bil");
+            expect(wordAtOffset(text, 5)).toBe("bil");
+        });
+
+        it("should name the word the caret sits against", () => {
+            // A click lands on a boundary as often as not, and both sides of one
+            // name the same word to the reader who clicked it.
+            const text = "en bil kör";
+            expect(wordAtOffset(text, 3)).toBe("bil");
+            expect(wordAtOffset(text, 6)).toBe("bil");
+        });
+
+        it("should keep Swedish letters whole", () => {
+            // The bug this pins: \w is ASCII-only, so the old expression turned
+            // björn into bjrn - in a Swedish dictionary, on the words a reader is
+            // most likely to need looked up.
+            expect(wordAtOffset("en björn sover", 5)).toBe("björn");
+            expect(wordAtOffset("ett träd", 6)).toBe("träd");
+            expect(wordAtOffset("på ön", 4)).toBe("ön");
+            expect(wordAtOffset("räksmörgås", 5)).toBe("räksmörgås");
+        });
+
+        it("should keep hyphenated and digit-bearing words whole", () => {
+            expect(wordAtOffset("e-post idag", 2)).toBe("e-post");
+            expect(wordAtOffset("v2 släpps", 1)).toBe("v2");
+        });
+
+        it("should return nothing where there is no word", () => {
+            // A caret with whitespace on both sides names nothing. Touching a word on
+            // either side is a hit, which is the previous test.
+            expect(wordAtOffset("en  bil", 3)).toBe("");
+            expect(wordAtOffset("   ", 1)).toBe("");
+            expect(wordAtOffset("", 0)).toBe("");
+        });
+
+        it("should tolerate an offset outside the text", () => {
+            // Nothing guarantees the caret API and the text node agree, and a throw
+            // here would take the whole lookup with it.
+            expect(wordAtOffset("en bil", 999)).toBe("bil");
+            expect(wordAtOffset("en bil", -5)).toBe("en");
+        });
+    });
+});

--- a/tests/unit/util/fakes.ts
+++ b/tests/unit/util/fakes.ts
@@ -16,11 +16,15 @@ import {
     LoadHistoryDirectionsHandler,
     RemoveHistoryItemHandler,
     PlayAudioHandler,
+    TranslateSelectionHandler,
+    IMessageBus,
+    MessageHandler,
     IAsyncStorage,
     IAsyncSettingsStorage,
     IAudioPlayer
 } from "../../../src/scripts/common/Interfaces.js";
 import TranslationDirection from "../../../src/scripts/dictionary/TranslationDirection.js";
+import MessageType from "../../../src/scripts/messaging/MessageType.js";
 
 export class FakeLoader implements ILoader {
     data: string[] = [];
@@ -88,6 +92,20 @@ export class TestMessageService implements IMessageService {
     playAudio(url: string): Promise<void> {
         this.playedAudioUrls.push(url);
         return Promise.resolve();
+    }
+
+    translateSelectionCalls = 0;
+
+    translateSelection(): Promise<void> {
+        this.translateSelectionCalls++;
+        return Promise.resolve();
+    }
+
+    /** What chrome://extensions/shortcuts would report. "" means unassigned. */
+    commandShortcut = "";
+
+    getCommandShortcut(_command: string): Promise<string> {
+        return Promise.resolve(this.commandShortcut);
     }
 }
 
@@ -259,5 +277,51 @@ export class FakeMessageHandlers implements IMessageHandlers {
 
     registerPlayAudioInOffscreenDocumentHandler(handler: PlayAudioHandler): void {
         this.playAudioInOffscreenDocumentHandler = handler;
+    }
+
+    translateSelectionHandler: TranslateSelectionHandler | null = null;
+
+    registerTranslateSelectionHandler(handler: TranslateSelectionHandler): void {
+        this.translateSelectionHandler = handler;
+    }
+}
+
+/**
+ * A bus that records what was sent and hands back the command handlers it was given,
+ * so a test can fire a keyboard shortcut without Chrome.
+ */
+export class FakeMessageBus implements IMessageBus {
+    sentToActiveTab: MessageType[] = [];
+    commandHandlers: { [command: string]: () => void } = {};
+    shortcuts: { [command: string]: string } = {};
+
+    registerHandler(_method: MessageType, _handler: MessageHandler, _ignoreEmptyResult?: boolean) {
+        // No-op: handler registration is FakeMessageHandlers' business.
+    }
+
+    sendMessage(_method: MessageType, _args?: any): Promise<any> {
+        return Promise.resolve(undefined);
+    }
+
+    sendMessageToActiveTab(method: MessageType, _args?: any): Promise<any> {
+        this.sentToActiveTab.push(method);
+        return Promise.resolve(undefined);
+    }
+
+    createNewTab(_url: string): void {
+        // No-op
+    }
+
+    registerCommandHandler(command: string, handler: () => void): void {
+        this.commandHandlers[command] = handler;
+    }
+
+    getCommandShortcut(command: string): Promise<string> {
+        return Promise.resolve(this.shortcuts[command] || "");
+    }
+
+    /** Fires a command as Chrome would, so a test need not touch chrome.commands. */
+    pressCommand(command: string): void {
+        this.commandHandlers[command]?.();
     }
 }


### PR DESCRIPTION
Alt+click was the only way to open a Translation Card, and on two platforms it never arrives:

- **ChromeOS (#21)** — Alt+click *is* the secondary click on a Chromebook. Ash, the window server, consumes it before the renderer is sent anything, so the page receives a `contextmenu` and never a left `click` carrying `altKey`. Google is also midway through moving this to `Search + click` behind a flag, so behaviour varies by ChromeOS version.
- **Linux (#15)** — GNOME's Mutter grabs Alt+click for window-move.

No content script wins an event it is never sent, so the only fix available is to stop hardcoding the trigger. Closes #17.

## What this adds

**A configurable modifier** — Alt (default), Ctrl or Shift, in Options. Alt stays the default, so readers who were not broken see no change.

**A `chrome.commands` shortcut** — `translate-selection`, suggested at `Ctrl+Shift+L`. A browser-level shortcut is the one trigger no desktop can intercept, and Chrome supplies the rebinding UI at `chrome://extensions/shortcuts`, so no key-capture widget ships here. `commands` is a manifest key, not a permission: `permissions` is still exactly `["storage", "offscreen"]`, and `ManifestTests` now says so explicitly so nobody "fixes" it to match.

## Hand-testing on macOS changed the design

Two defects the obvious implementation would have shipped:

**Ctrl+double-click opened the context menu.** macOS defines Ctrl+click as the secondary click, so Chrome raises `contextmenu` off the mousedown and suppresses the `click` entirely. No listener ordering recovers it, so **Ctrl is not offered on a Mac**. A Mac needs no escape hatch anyway — Option+click, the default, works fine there.

**Shift+click expanded the selection**, and that turned out to be *two* bugs:
- the wrong word was looked up → fixed by the double-click path naming its word by **position** (`wordAtPoint`) rather than by reading the selection;
- the page itself visibly selected half a paragraph → fixed by `preventDefault` on `mousedown`.

Each fix passes the other's test, which was found by removing each and watching, so `trigger.spec.ts` covers them as two separate tests.

**The mousedown `preventDefault` is Shift-only.** Alt and Ctrl replace the selection rather than extending it, so they have nothing to fix — and suppressing their default throws away the browser's own double-click word selection, which the dblclick handler still wants as a fallback. That fallback is not theoretical: `caretRangeFromPoint` answers for points inside the viewport only. Applying it unconditionally broke six style-isolation tests before it was narrowed.

## Behaviour changes worth knowing

- **Matching is exclusive** — `Alt+Shift+click` used to open a card and no longer does. With three modifiers to choose between, a permissive match would fire `Ctrl+Shift+click` for a Ctrl reader *and* a Shift reader, and AltGr on Windows is literally Ctrl+Alt.
- **The `altKeyDown` tracker is deleted.** It was stale state by construction: `keyup` is never delivered if the key is released while the document lacks focus, so one Alt+Tab left it stuck `true` and *any* plain double-click opened a card. Generalising it to three modifiers would have made Shift+Tab and Ctrl+Tab do the same.
- **The two mouse paths now mean different things** — double-click asks "the word I am pointing at", single click asks "what I selected". That makes double-click immune to every selection oddity, including a stale selection from a previous lookup.

## Two latent bugs fixed on the way

Moving `wordAtPoint` from fallback to primary put both on the hot path:

- `/(\w+)$/` is ASCII-only — `björn` was becoming `bjrn`, in a *Swedish* dictionary.
- The `caretPositionFromPoint` branch read a `CaretPosition` as if it were a `Range` (`startContainer`/`startOffset` vs `offsetNode`/`offset`). Dormant in Chrome today; live the day `caretRangeFromPoint` goes.

## The extension's first `chrome.storage.onChanged` listener

Watching one key. Every other setting is re-read by the action that displays it, so staleness heals after one card. The trigger cannot work that way: a reader changes it precisely because their desktop intercepts the current one, so the page they were reading has no way to open a card and re-read on its own — waiting would look exactly like the setting doing nothing.

## Copy

The help page, popup empty state and History empty state now name the key the reader chose, engraved as their own keyboard has it (a Mac says Option). The smoke assertions compute the same label rather than hardcoding Alt, so the suite reads the same on a laptop and on Linux CI.

## Testing

`npm run lint`, `npm run typecheck`, **282 unit tests**, **67 e2e tests** — all green.

New: `LookupTriggerTests` (the `matchesTrigger` truth table incl. exclusivity), `WordAtPointTests` (incl. `björn`), `trigger.spec.ts` (10 tests), plus `commands` and `translateSelection` coverage. The seven duplicated Alt+dblclick e2e call sites collapse into one `ExtensionHelpers.triggerLookup` helper.

**What the tests cannot prove:** Playwright drives Chrome over CDP, which injects input *below* the layer where Ash and Mutter take Alt+click. The original bug is not reproducible in the suite on any platform, and no test will ever fail because of it. Chrome's dispatch of a keystroke to `onCommand` is likewise unreachable — `page.keyboard.press` goes to the renderer — so the command tests drive the worker's handler directly. Both are stated in the spec files.

**Still to verify by hand:** the interception itself, on ChromeOS or GNOME.

Reasoning recorded in `docs/adr/0005-configurable-lookup-trigger.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
