### PR TITLE
Fix overlapping history writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,10 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # The build only compiles src. This is what covers tests/, which vitest and
+      # Playwright otherwise just strip types from without checking them.
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Test
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:copy": "cp -r src/css dist/ && cp -r src/html dist/ && cp -r src/icons dist/ && npm run build:manifest",
     "build": "npm run build:ts && npm run build:bundle && npm run build:copy",
     "watch": "node build.js --watch",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tests/tsconfig.json && tsc -p tests/e2e/tsconfig.json",
     "lint": "eslint 'src/**/*.{ts,js}'",
     "lint:fix": "eslint 'src/**/*.{ts,js}' --fix",
     "test": "vitest run",

--- a/src/scripts/history/HistoryManager.ts
+++ b/src/scripts/history/HistoryManager.ts
@@ -20,11 +20,9 @@ class HistoryManager implements IHistoryManager {
         this.maxHistory = 1000;
     }
 
+    /** Returns decoded, deduplicated and date-sorted history for one direction. */
     getHistory(langDirection: string): Promise<IHistoryItem[]> {
         return this.runSerialized(langDirection, async () => {
-            //  Summary
-            //      Returns translation history for the specified language direction.
-
             const history = await this.loadHistory(langDirection);
             // remove duplicates. We do it only on history request since we don"t want to do it on every translation operation
             this.compress(history);
@@ -33,17 +31,86 @@ class HistoryManager implements IHistoryManager {
         });
     }
 
+    /** Clears translation history for one direction. */
+    clearHistory(langDirection: string): Promise<void> {
+        return this.runSerialized(langDirection, async () => {
+            await this.storage.removeItem(this.getStorageKey(langDirection));
+        });
+    }
+
+    /**
+     * Which Language Directions have anything stored.
+     *
+     * Read off the keys rather than kept as an index: an index would be one more thing
+     * to keep in step with addToHistory and clearHistory, and it would go stale for
+     * anyone upgrading from a build that never wrote it.
+     *
+     * The key existing is not enough - an empty array gets written whenever a direction
+     * is merely *looked at* (opening the Action Popup refreshes its Recent row through
+     * getHistory) and when its last row is deleted. Reading each one keeps the History
+     * page from growing a tab per language the reader once had selected.
+     *
+     * This read deliberately stays outside the per-direction operation queues because
+     * it spans every direction. It can produce a momentarily stale tab list while a
+     * first addition or clear is in flight; the next refresh corrects that harmless
+     * UI state, and getDirections never writes its snapshot back.
+     */
+    async getDirections(): Promise<string[]> {
+        const keys = await this.storage.keys();
+        const candidates = keys
+            .filter((key) => key.indexOf(this.storageKey) === 0 && key.length > this.storageKey.length);
+        const stored = await Promise.all(candidates.map((key) => this.storage.getItem(key)));
+        return candidates
+            .filter((key, index) => this.hasEntries(stored[index]))
+            .map((key) => key.substring(this.storageKey.length));
+    }
+
+    /**
+     * Removes one entry, for the History page's per-row delete.
+     *
+     * Matched on word *and* timestamp: _removeDuplicates merges same-word entries
+     * across lookups, so a word on its own does not identify a row.
+     */
+    removeItem(langDirection: string, word: string, added: number): Promise<void> {
+        return this.runSerialized(langDirection, async () => {
+            const history = await this.loadHistory(langDirection);
+            const remaining = history.filter((item) => !(item.word === word && item.added === added));
+            if (remaining.length !== history.length) {
+                await this.saveHistory(langDirection, remaining);
+            }
+        });
+    }
+
+    /** Adds parsed translations to one direction's history. */
+    addToHistory(langDirection: string, translations: IHistoryItem[]): Promise<void> {
+        return this.runSerialized(langDirection, async () => {
+            let history = await this.loadHistory(langDirection);
+            if (!history) {
+                history = [];
+            }
+            history = history.concat(translations);
+            if (this.needToCompress(history)) {
+                this.compress(history);
+            }
+            const serializedHistory = JSON.stringify(history);
+            await this.storage.setItem(this.getStorageKey(langDirection), serializedHistory);
+        });
+    }
+
     /**
      * Runs each direction's read-modify-write operations one at a time.
      *
      * chrome.storage.local has no atomic update operation, so every operation must
-     * finish before the next one reads that direction. The queue tail absorbs a
-     * failure to keep later work moving, while the operation's own promise still
-     * rejects for its caller.
+     * finish before the next one reads that direction. The non-rejecting queue tail
+     * keeps later work moving after a failure, while the operation's own promise
+     * still rejects for its caller.
+     *
+     * Never call another serialized method for the same direction from inside
+     * `operation`: the inner call would wait for the outer call's own tail.
      */
     private runSerialized<T>(langDirection: string, operation: () => Promise<T>): Promise<T> {
         const previous = this.operations.get(langDirection) || Promise.resolve();
-        const result = previous.catch(() => undefined).then(operation);
+        const result = previous.then(operation);
         const tail = result.then(() => undefined, () => undefined);
         this.operations.set(langDirection, tail);
 
@@ -83,36 +150,6 @@ class HistoryManager implements IHistoryManager {
         return this.storageKey + langDirection;
     }
 
-    clearHistory(langDirection: string): Promise<void> {
-        return this.runSerialized(langDirection, async () => {
-            //  Summary
-            //      Clears translation history for the specified language direction
-            await this.storage.removeItem(this.getStorageKey(langDirection));
-        });
-    }
-
-    /**
-     * Which Language Directions have anything stored.
-     *
-     * Read off the keys rather than kept as an index: an index would be one more thing
-     * to keep in step with addToHistory and clearHistory, and it would go stale for
-     * anyone upgrading from a build that never wrote it.
-     *
-     * The key existing is not enough - an empty array gets written whenever a direction
-     * is merely *looked at* (opening the Action Popup refreshes its Recent row through
-     * getHistory) and when its last row is deleted. Reading each one keeps the History
-     * page from growing a tab per language the reader once had selected.
-     */
-    async getDirections(): Promise<string[]> {
-        const keys = await this.storage.keys();
-        const candidates = keys
-            .filter((key) => key.indexOf(this.storageKey) === 0 && key.length > this.storageKey.length);
-        const stored = await Promise.all(candidates.map((key) => this.storage.getItem(key)));
-        return candidates
-            .filter((key, index) => this.hasEntries(stored[index]))
-            .map((key) => key.substring(this.storageKey.length));
-    }
-
     /** A store counts as a direction only once something has actually been looked up in it. */
     private hasEntries(storedHistory: string | null): boolean {
         if (!storedHistory) {
@@ -125,40 +162,6 @@ class HistoryManager implements IHistoryManager {
             // A key we cannot read is a key the History page cannot show either.
             return false;
         }
-    }
-
-    /**
-     * Removes one entry, for the History page's per-row delete.
-     *
-     * Matched on word *and* timestamp: _removeDuplicates merges same-word entries
-     * across lookups, so a word on its own does not identify a row.
-     */
-    removeItem(langDirection: string, word: string, added: number): Promise<void> {
-        return this.runSerialized(langDirection, async () => {
-            const history = await this.loadHistory(langDirection);
-            const remaining = history.filter((item) => !(item.word === word && item.added === added));
-            if (remaining.length !== history.length) {
-                await this.saveHistory(langDirection, remaining);
-            }
-        });
-    }
-
-    addToHistory(langDirection: string, translations: IHistoryItem[]): Promise<void> {
-        return this.runSerialized(langDirection, async () => {
-            //  Summary
-            //      Adds a new word and translation to the translation history
-
-            let history = await this.loadHistory(langDirection);
-            if (!history) {
-                history = [];
-            }
-            history = history.concat(translations);
-            if (this.needToCompress(history)) {
-                this.compress(history);
-            }
-            const serializedHistory = JSON.stringify(history);
-            await this.storage.setItem(this.getStorageKey(langDirection), serializedHistory);
-        });
     }
 
     private _removeDuplicates(history: IHistoryItem[]): void {

--- a/src/scripts/history/HistoryManager.ts
+++ b/src/scripts/history/HistoryManager.ts
@@ -114,11 +114,16 @@ class HistoryManager implements IHistoryManager {
         const tail = result.then(() => undefined, () => undefined);
         this.operations.set(langDirection, tail);
 
-        void tail.then(() => {
+        // Settled either way, so the entry is dropped on both paths. A
+        // fulfilment-only handler would work today, but it would leave a rejected
+        // tail in the map forever if the tail ever propagated one - and every later
+        // operation on that direction would chain onto it and silently never run.
+        const forget = () => {
             if (this.operations.get(langDirection) === tail) {
                 this.operations.delete(langDirection);
             }
-        });
+        };
+        void tail.then(forget, forget);
 
         return result;
     }

--- a/src/scripts/history/HistoryManager.ts
+++ b/src/scripts/history/HistoryManager.ts
@@ -7,6 +7,7 @@ class HistoryManager implements IHistoryManager {
     private storage: IAsyncStorage;
     private maxHistoryBuffer: number;
     private maxHistoryLength: number;
+    private operations = new Map<string, Promise<void>>();
 
     set maxHistory(value: number) {
         this.maxHistoryLength = value;
@@ -19,15 +20,40 @@ class HistoryManager implements IHistoryManager {
         this.maxHistory = 1000;
     }
 
-    async getHistory(langDirection: string): Promise<IHistoryItem[]> {
-        //  Summary
-        //      Returns translation history for the specified language direction.
+    getHistory(langDirection: string): Promise<IHistoryItem[]> {
+        return this.runSerialized(langDirection, async () => {
+            //  Summary
+            //      Returns translation history for the specified language direction.
 
-        const history = await this.loadHistory(langDirection);
-        // remove duplicates. We do it only on history request since we don"t want to do it on every translation operation
-        this.compress(history);
-        await this.saveHistory(langDirection,  history);
-        return history;
+            const history = await this.loadHistory(langDirection);
+            // remove duplicates. We do it only on history request since we don"t want to do it on every translation operation
+            this.compress(history);
+            await this.saveHistory(langDirection,  history);
+            return history;
+        });
+    }
+
+    /**
+     * Runs each direction's read-modify-write operations one at a time.
+     *
+     * chrome.storage.local has no atomic update operation, so every operation must
+     * finish before the next one reads that direction. The queue tail absorbs a
+     * failure to keep later work moving, while the operation's own promise still
+     * rejects for its caller.
+     */
+    private runSerialized<T>(langDirection: string, operation: () => Promise<T>): Promise<T> {
+        const previous = this.operations.get(langDirection) || Promise.resolve();
+        const result = previous.catch(() => undefined).then(operation);
+        const tail = result.then(() => undefined, () => undefined);
+        this.operations.set(langDirection, tail);
+
+        void tail.then(() => {
+            if (this.operations.get(langDirection) === tail) {
+                this.operations.delete(langDirection);
+            }
+        });
+
+        return result;
     }
 
     private async loadHistory(langDirection: string): Promise<IHistoryItem[]> {
@@ -57,10 +83,12 @@ class HistoryManager implements IHistoryManager {
         return this.storageKey + langDirection;
     }
 
-    async clearHistory(langDirection: string): Promise<void> {
-        //  Summary
-        //      Clears translation history for the specified language direction
-        await this.storage.removeItem(this.getStorageKey(langDirection));
+    clearHistory(langDirection: string): Promise<void> {
+        return this.runSerialized(langDirection, async () => {
+            //  Summary
+            //      Clears translation history for the specified language direction
+            await this.storage.removeItem(this.getStorageKey(langDirection));
+        });
     }
 
     /**
@@ -105,28 +133,32 @@ class HistoryManager implements IHistoryManager {
      * Matched on word *and* timestamp: _removeDuplicates merges same-word entries
      * across lookups, so a word on its own does not identify a row.
      */
-    async removeItem(langDirection: string, word: string, added: number): Promise<void> {
-        const history = await this.loadHistory(langDirection);
-        const remaining = history.filter((item) => !(item.word === word && item.added === added));
-        if (remaining.length !== history.length) {
-            await this.saveHistory(langDirection, remaining);
-        }
+    removeItem(langDirection: string, word: string, added: number): Promise<void> {
+        return this.runSerialized(langDirection, async () => {
+            const history = await this.loadHistory(langDirection);
+            const remaining = history.filter((item) => !(item.word === word && item.added === added));
+            if (remaining.length !== history.length) {
+                await this.saveHistory(langDirection, remaining);
+            }
+        });
     }
 
-    async addToHistory(langDirection: string, translations: IHistoryItem[]): Promise<void> {
-        //  Summary
-        //      Adds a new word and translation to the translation history
+    addToHistory(langDirection: string, translations: IHistoryItem[]): Promise<void> {
+        return this.runSerialized(langDirection, async () => {
+            //  Summary
+            //      Adds a new word and translation to the translation history
 
-        let history = await this.loadHistory(langDirection);
-        if (!history) {
-            history = [];
-        }
-        history = history.concat(translations);
-        if (this.needToCompress(history)) {
-            this.compress(history);
-        }
-        const serializedHistory = JSON.stringify(history);
-        await this.storage.setItem(this.getStorageKey(langDirection), serializedHistory);
+            let history = await this.loadHistory(langDirection);
+            if (!history) {
+                history = [];
+            }
+            history = history.concat(translations);
+            if (this.needToCompress(history)) {
+                this.compress(history);
+            }
+            const serializedHistory = JSON.stringify(history);
+            await this.storage.setItem(this.getStorageKey(langDirection), serializedHistory);
+        });
     }
 
     private _removeDuplicates(history: IHistoryItem[]): void {

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -432,8 +432,9 @@ test.describe("Lookup trigger", () => {
             // from earlier, and a double-click somewhere else. The word that wins is
             // the one under the pointer.
             //
-            // The final card proves which lookup won visually; serialized history
-            // also proves a spurious lookup of the existing selection never happened.
+            // The final card proves which lookup won visually. Once both possible
+            // requests have had time to settle, serialized history also reveals
+            // whether a spurious lookup of the existing selection happened.
             await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
             await ExtensionHelpers.setLanguage(context, extensionId, "swe_swe");
             await ExtensionHelpers.seedHistory(context, extensionId, { swe_swe: [] });
@@ -456,6 +457,10 @@ test.describe("Lookup trigger", () => {
             // its body to leave the loading state; the response follows the awaited
             // history write, so storage is settled once this does.
             await expect(page.locator(CARD)).not.toContainText("Searching", { timeout: 15000 });
+            // A spurious lookup of "bil" would be a separate request and could finish
+            // after the visible "hund" card. Give it the same settle window as the
+            // duplicate-lookup regression above before asserting its absence.
+            await page.waitForTimeout(1500);
 
             const stored = await ExtensionHelpers.getStoredValue(context, extensionId, "historyswe_swe");
             const entries = JSON.parse(stored || "[]") as { word: string }[];

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -452,6 +452,10 @@ test.describe("Lookup trigger", () => {
             await ExtensionHelpers.triggerLookup(page, "#second-word", { modifier: "Shift" });
 
             await expect(page.locator(CARD_WORD)).toHaveText("hund");
+            // The header is rendered before the dictionary request starts. Wait for
+            // its body to leave the loading state; the response follows the awaited
+            // history write, so storage is settled once this does.
+            await expect(page.locator(CARD)).not.toContainText("Searching", { timeout: 15000 });
 
             const stored = await ExtensionHelpers.getStoredValue(context, extensionId, "historyswe_swe");
             const entries = JSON.parse(stored || "[]") as { word: string }[];

--- a/tests/e2e/trigger.spec.ts
+++ b/tests/e2e/trigger.spec.ts
@@ -406,10 +406,9 @@ test.describe("Lookup trigger", () => {
             // before opening its own, so a duplicate leaves exactly one card behind
             // and is invisible from the page.
             //
-            // History is the only witness, and an imperfect one - two writes this
-            // close together can read the same store and one overwrite the other, so
-            // a duplicate is occasionally undercounted. It never overcounts, so a
-            // failure here is always real.
+            // History is the only witness. Its writes are serialized, so every
+            // completed lookup is represented and a duplicate cannot hide behind a
+            // later write.
             await ExtensionHelpers.setLanguage(context, extensionId, "swe_swe");
             await ExtensionHelpers.seedHistory(context, extensionId, { swe_swe: [] });
 
@@ -433,13 +432,11 @@ test.describe("Lookup trigger", () => {
             // from earlier, and a double-click somewhere else. The word that wins is
             // the one under the pointer.
             //
-            // Only the final card is asserted, deliberately. A spurious lookup here
-            // would be dismissed a moment later by the double-click's own card, and
-            // history cannot see it either - two lookups this close together
-            // read-modify-write the same store and one can overwrite the other. The
-            // gate itself is pinned by the single-click test above, where a wrong
-            // lookup has nothing to hide behind.
+            // The final card proves which lookup won visually; serialized history
+            // also proves a spurious lookup of the existing selection never happened.
             await ExtensionHelpers.setTriggerModifier(context, extensionId, "shift");
+            await ExtensionHelpers.setLanguage(context, extensionId, "swe_swe");
+            await ExtensionHelpers.seedHistory(context, extensionId, { swe_swe: [] });
 
             const page = await context.newPage();
             await openTestPage(page);
@@ -455,6 +452,11 @@ test.describe("Lookup trigger", () => {
             await ExtensionHelpers.triggerLookup(page, "#second-word", { modifier: "Shift" });
 
             await expect(page.locator(CARD_WORD)).toHaveText("hund");
+
+            const stored = await ExtensionHelpers.getStoredValue(context, extensionId, "historyswe_swe");
+            const entries = JSON.parse(stored || "[]") as { word: string }[];
+            expect(entries.some((entry) => entry.word === "hund")).toBe(true);
+            expect(entries.some((entry) => entry.word === "bil")).toBe(false);
         });
 
     test("a plain click should still dismiss the card", async ({ context, extensionId }) => {

--- a/tests/unit/HistoryManagerTests.ts
+++ b/tests/unit/HistoryManagerTests.ts
@@ -15,6 +15,35 @@ class FailOnceAsyncStorage extends FakeAsyncStorage {
     }
 }
 
+class BlockingAsyncStorage extends FakeAsyncStorage {
+    private blocked = false;
+    private releaseRead: () => void = () => {};
+    private reportBlockedRead: () => void = () => {};
+    private readGate = new Promise<void>((resolve) => {
+        this.releaseRead = resolve;
+    });
+    readonly blockedRead = new Promise<void>((resolve) => {
+        this.reportBlockedRead = resolve;
+    });
+
+    constructor(private blockedKey: string) {
+        super();
+    }
+
+    async getItem(key: string): Promise<string | null> {
+        if (key === this.blockedKey && !this.blocked) {
+            this.blocked = true;
+            this.reportBlockedRead();
+            await this.readGate;
+        }
+        return super.getItem(key);
+    }
+
+    release(): void {
+        this.releaseRead();
+    }
+}
+
 describe("HistoryManager", () => {
     let historyManager: HistoryManager;
     let fakeStorage: FakeAsyncStorage;
@@ -286,10 +315,39 @@ describe("HistoryManager", () => {
             const failed = {word: "failed", translation: "one", added: 1};
             const retained = {word: "retained", translation: "two", added: 2};
 
-            await expect(manager.addToHistory("swe_foo", [failed])).rejects.toThrow("setItem failed");
-            await manager.addToHistory("swe_foo", [retained]);
+            const failing = manager.addToHistory("swe_foo", [failed]);
+            const following = manager.addToHistory("swe_foo", [retained]);
+
+            await expect(failing).rejects.toThrow("setItem failed");
+            await following;
 
             expect(await manager.getHistory("swe_foo")).toEqual([retained]);
+        });
+
+        it("should let another language direction proceed independently", async () => {
+            const blockingStorage = new BlockingAsyncStorage("historyswe_foo");
+            const manager = new HistoryManager(new TranslationParser(), blockingStorage);
+            const blocked = manager.addToHistory("swe_foo", [
+                {word: "blocked", translation: "one", added: 1}
+            ]);
+            await blockingStorage.blockedRead;
+
+            let independentCompleted = false;
+            const independent = manager.addToHistory("swe_bar", [
+                {word: "independent", translation: "two", added: 2}
+            ]).then(() => {
+                independentCompleted = true;
+            });
+
+            // A timer runs only after the promise queue has drained. Capture the
+            // result before releasing swe_foo, then release it even if the assertion
+            // is going to fail so the test leaves no pending operation behind.
+            await new Promise<void>((resolve) => setTimeout(resolve, 0));
+            const completedBeforeRelease = independentCompleted;
+            blockingStorage.release();
+            await Promise.all([blocked, independent]);
+
+            expect(completedBeforeRelease).toBe(true);
         });
     });
 

--- a/tests/unit/HistoryManagerTests.ts
+++ b/tests/unit/HistoryManagerTests.ts
@@ -3,6 +3,18 @@ import HistoryManager from "../../src/scripts/history/HistoryManager.js";
 import TranslationParser from "../../src/scripts/dictionary/TranslationParser.js";
 import { FakeAsyncStorage } from "./util/fakes.js";
 
+class FailOnceAsyncStorage extends FakeAsyncStorage {
+    private shouldFailSet = true;
+
+    async setItem(key: string, value: string): Promise<void> {
+        if (this.shouldFailSet) {
+            this.shouldFailSet = false;
+            throw new Error("setItem failed");
+        }
+        await super.setItem(key, value);
+    }
+}
+
 describe("HistoryManager", () => {
     let historyManager: HistoryManager;
     let fakeStorage: FakeAsyncStorage;
@@ -214,6 +226,70 @@ describe("HistoryManager", () => {
 
             expect(history_swe_foo.length).toBe(0);
             expect(history_swe_bar.length).toBe(1);
+        });
+    });
+
+    describe("concurrent operations", () => {
+        it("should preserve two additions to the same language direction", async () => {
+            const first = {word: "first", translation: "one", added: 1};
+            const second = {word: "second", translation: "two", added: 2};
+
+            await Promise.all([
+                historyManager.addToHistory("swe_foo", [first]),
+                historyManager.addToHistory("swe_foo", [second])
+            ]);
+
+            const history = await historyManager.getHistory("swe_foo");
+            expect(history.map((item) => item.word).sort()).toEqual(["first", "second"]);
+        });
+
+        it("should let a history read observe an addition started before it", async () => {
+            const item = {word: "test_word", translation: "test_translation", added: 1};
+
+            const [, history] = await Promise.all([
+                historyManager.addToHistory("swe_foo", [item]),
+                historyManager.getHistory("swe_foo")
+            ]);
+
+            expect(history).toEqual([item]);
+        });
+
+        it("should not lose an addition when a later removal overlaps it", async () => {
+            const removed = {word: "removed", translation: "old", added: 1};
+            const retained = {word: "retained", translation: "new", added: 2};
+            await historyManager.addToHistory("swe_foo", [removed]);
+
+            await Promise.all([
+                historyManager.addToHistory("swe_foo", [retained]),
+                historyManager.removeItem("swe_foo", removed.word, removed.added)
+            ]);
+
+            expect(await historyManager.getHistory("swe_foo")).toEqual([retained]);
+        });
+
+        it("should not let an earlier addition restore cleared history", async () => {
+            const original = {word: "original", translation: "old", added: 1};
+            const added = {word: "added", translation: "new", added: 2};
+            await historyManager.addToHistory("swe_foo", [original]);
+
+            await Promise.all([
+                historyManager.addToHistory("swe_foo", [added]),
+                historyManager.clearHistory("swe_foo")
+            ]);
+
+            expect(await historyManager.getHistory("swe_foo")).toEqual([]);
+        });
+
+        it("should continue processing after a storage operation fails", async () => {
+            const failingStorage = new FailOnceAsyncStorage();
+            const manager = new HistoryManager(new TranslationParser(), failingStorage);
+            const failed = {word: "failed", translation: "one", added: 1};
+            const retained = {word: "retained", translation: "two", added: 2};
+
+            await expect(manager.addToHistory("swe_foo", [failed])).rejects.toThrow("setItem failed");
+            await manager.addToHistory("swe_foo", [retained]);
+
+            expect(await manager.getHistory("swe_foo")).toEqual([retained]);
         });
     });
 


### PR DESCRIPTION
## Summary

- serialize history read-modify-write operations per language direction
- cover overlapping additions, reads, removals, clears, and queue recovery after storage failures
- strengthen the lookup-trigger E2E coverage now that history is a reliable witness

## Root cause

History operations independently loaded, modified, and saved the same `chrome.storage.local` value. Overlapping lookups could therefore read the same snapshot and let the later write silently discard an earlier entry.

The fix queues operations for each language direction while allowing unrelated directions to continue independently. Caller-visible failures still reject, but do not poison later queued work.

## User impact

Closely timed lookups no longer lose history entries, and clear/remove operations cannot race with an in-flight addition and restore or discard the wrong data.

## Validation

- `npm run lint`
- `npm run test` — 26 files, 287 tests passed
- `npm run test:e2e -- tests/e2e/trigger.spec.ts` — 23 tests passed
- `git diff --check`

Fixes #68