### PR TITLE
Fix Playwright trace artifacts on failed tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -77,8 +77,8 @@ export default defineConfig({
     // Video recording on failure
     video: "retain-on-failure",
     
-    // Trace on first retry
-    trace: "on-first-retry",
+    // Keep traces for failed test runs so CI uploads include a trace.zip for debugging.
+    trace: "retain-on-failure",
   },
   
   // Projects configuration


### PR DESCRIPTION
### Motivation
- Ensure Playwright keeps trace artifacts for failed runs so CI uploads include a `trace.zip` for debugging when end-to-end tests fail.

### Description
- Change in `playwright.config.ts`: replaced `trace: "on-first-retry"` with `trace: "retain-on-failure"` and updated the comment to reflect retaining traces for failed runs.

### Testing
- Ran `npm run typecheck` which completed successfully.
- Ran `npm test` (Vitest) and all unit tests passed (26 files, 282 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a732d66b5b8832f950244cd4b3b15d6)